### PR TITLE
ci(github): re-enable macos-latest in test matrix :sparkles:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,18 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest] # macos-latest
+        os: [ubuntu-latest, macos-latest]
+    # macOS notes:
+    #   - The chezmoi run_onchange scripts gate on $CI / $GITHUB_ACTIONS to
+    #     skip GUI-bound work (macOS preferences, nvim Lazy! sync, Claude Code
+    #     installer) and Homebrew casks (GUI apps / paid software / GUI auth).
+    #   - Brew formulas (CLI tools) still install so we catch bundle drift.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/home/.chezmoiscripts/run_once_install-claude-code.sh
+++ b/home/.chezmoiscripts/run_once_install-claude-code.sh
@@ -9,6 +9,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Skip on CI: Claude Code isn't exercised in the install matrix and the
+# curl-pipe installer is unnecessary network traffic for green CI.
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+  echo "Running in CI, skipping Claude Code install"
+  exit 0
+fi
+
 # Skip if claude is already installed
 if command -v claude >/dev/null 2>&1; then
   echo "Claude Code already installed: $(claude --version 2>/dev/null || echo 'version unknown')"

--- a/home/.chezmoiscripts/run_onchange_configure-macos-preferences.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_configure-macos-preferences.sh.tmpl
@@ -5,6 +5,13 @@
 set -o errexit
 set -o nounset
 
+# Skip on CI: these tweaks need a GUI session (osascript / System Events,
+# killall Dock, killall ControlCenter, wallpaper via System Events).
+if [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
+    echo "Running in CI, skipping macOS preferences"
+    exit 0
+fi
+
 # Disable Spotlight's Cmd+Space (HotKey 64)
 # Parameters: ASCII 32 (space), virtual keycode 49 (space), modifiers 1048576 (Cmd)
 if [ "$(plutil -extract AppleSymbolicHotKeys.64.enabled raw -o - ~/Library/Preferences/com.apple.symbolichotkeys.plist 2>/dev/null)" = "false" ]; then

--- a/home/.chezmoiscripts/run_onchange_install-nvim-plugins.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_install-nvim-plugins.sh.tmpl
@@ -10,6 +10,13 @@ if [[ "${DEBUG:-}" == "1" ]]; then
     echo "🔄 Installing/updating Neovim plugins due to configuration changes..."
 fi
 
+# Skip on CI: Lazy! sync hits the network for every plugin and is the slowest
+# part of chezmoi apply; not worth the runtime in CI.
+if [[ -n "${CI:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "Running in CI, skipping Neovim plugin sync"
+    exit 0
+fi
+
 # Check if nvim is available
 if ! command -v nvim >/dev/null 2>&1; then
     echo "Warning: Neovim not found, skipping plugin installation"

--- a/home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl
@@ -11,15 +11,25 @@ if ! command -v brew >/dev/null 2>&1; then
     exit 0
 fi
 
+{{ if or (env "CI") (env "GITHUB_ACTIONS") -}}
+echo "Installing packages via brew bundle (CI: brews only, casks skipped)..."
+{{- else -}}
 echo "Installing packages via brew bundle..."
+{{- end }}
 
 brew bundle --file=/dev/stdin <<EOF
 {{ range .packages.darwin.brews -}}
 brew {{ . | quote }}
 {{ end -}}
+{{- /* Casks are skipped on CI: most are GUI apps (Cursor, 1Password, Slack,
+       VS Code, Ghostty, Obsidian, VLC, Loopback) that take many minutes to
+       download/install and some require licenses or GUI auth. Brew drift
+       (the formula list) is still validated. */ -}}
+{{ if not (or (env "CI") (env "GITHUB_ACTIONS")) -}}
 {{ range .packages.darwin.casks -}}
 cask {{ . | quote }}
 {{ end -}}
+{{- end }}
 EOF
 echo "Package installation complete"
 {{ end -}}

--- a/test/run_onchange_install-packages-darwin.bats
+++ b/test/run_onchange_install-packages-darwin.bats
@@ -42,7 +42,7 @@ load test_helper
   cat >"$TEST_TMPDIR/real-config.toml" <<EOF
 [data]
     chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
-    packages = { darwin = { brews = [], casks = ["font-fira-code-nerd-font"] } }
+    packages = { darwin = { brews = [], casks = ["font-maple-mono-nf-cn"] } }
 EOF
 
   # Render our actual script. The template branches on $CI / $GITHUB_ACTIONS
@@ -62,7 +62,7 @@ EOF
   [[ "$output" == *"brew bundle"* ]]
 
   # 4. Should contain our actual package
-  [[ "$output" == *"font-fira-code-nerd-font"* ]]
+  [[ "$output" == *"font-maple-mono-nf-cn"* ]]
 
   # 5. Should handle missing Homebrew gracefully
   [[ "$output" == *"Homebrew not found"* ]]
@@ -75,7 +75,7 @@ EOF
   cat >"$TEST_TMPDIR/ci-config.toml" <<EOF
 [data]
     chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
-    packages = { darwin = { brews = ["jq"], casks = ["font-fira-code-nerd-font"] } }
+    packages = { darwin = { brews = ["jq"], casks = ["font-maple-mono-nf-cn"] } }
 EOF
 
   CI=true run env -u GITHUB_ACTIONS chezmoi execute-template --config "$TEST_TMPDIR/ci-config.toml" --file "$script_file"
@@ -85,7 +85,7 @@ EOF
   [[ "$output" == *'brew "jq"'* ]]
 
   # Casks omitted from the rendered bundle
-  [[ "$output" != *"font-fira-code-nerd-font"* ]]
+  [[ "$output" != *"font-maple-mono-nf-cn"* ]]
   [[ "$output" != *'cask "'* ]]
 }
 
@@ -97,7 +97,7 @@ EOF
   cat >"$TEST_TMPDIR/linux-config.toml" <<EOF
 [data]
     chezmoi = { os = "linux", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
-    packages = { darwin = { brews = [], casks = ["font-fira-code-nerd-font"] } }
+    packages = { darwin = { brews = [], casks = ["font-maple-mono-nf-cn"] } }
 EOF
 
   # Render our actual script on linux
@@ -120,7 +120,7 @@ EOF
 
   # Add our actual packages data
   cat >>"$TEST_TMPDIR/syntax-config.toml" <<EOF
-    packages = { darwin = { brews = [], casks = ["font-fira-code-nerd-font"] } }
+    packages = { darwin = { brews = [], casks = ["font-maple-mono-nf-cn"] } }
 EOF
 
   # Render our actual script

--- a/test/run_onchange_install-packages-darwin.bats
+++ b/test/run_onchange_install-packages-darwin.bats
@@ -45,8 +45,10 @@ load test_helper
     packages = { darwin = { brews = [], casks = ["font-fira-code-nerd-font"] } }
 EOF
 
-  # Render our actual script
-  run chezmoi execute-template --config "$TEST_TMPDIR/real-config.toml" --file "$script_file"
+  # Render our actual script. The template branches on $CI / $GITHUB_ACTIONS
+  # at render time; clear them so this test exercises the dev-machine path
+  # (brews + casks). The CI-only path is covered by a separate test below.
+  run env -u CI -u GITHUB_ACTIONS chezmoi execute-template --config "$TEST_TMPDIR/real-config.toml" --file "$script_file"
   [ "$status" -eq 0 ]
 
   # Test our script's behavior:
@@ -65,6 +67,26 @@ EOF
   # 5. Should handle missing Homebrew gracefully
   [[ "$output" == *"Homebrew not found"* ]]
   [[ "$output" == *"exit 0"* ]]
+}
+
+@test "skips casks when CI env is set" {
+  local script_file="home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl"
+
+  cat >"$TEST_TMPDIR/ci-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    packages = { darwin = { brews = ["jq"], casks = ["font-fira-code-nerd-font"] } }
+EOF
+
+  CI=true run env -u GITHUB_ACTIONS chezmoi execute-template --config "$TEST_TMPDIR/ci-config.toml" --file "$script_file"
+  [ "$status" -eq 0 ]
+
+  # Brews still installed (catches bundle drift in CI)
+  [[ "$output" == *'brew "jq"'* ]]
+
+  # Casks omitted from the rendered bundle
+  [[ "$output" != *"font-fira-code-nerd-font"* ]]
+  [[ "$output" != *'cask "'* ]]
 }
 
 @test "does not render on non-darwin systems" {


### PR DESCRIPTION
Closes #8.

## Why

CI only ran on `ubuntu-latest`, so macOS-only paths in this repo (Homebrew bundle, darwin-conditional chezmoi templates, `private_Library/`) had no automated coverage. The issue calls out brew bundle drift and macOS template regressions as the main gap.

## What

- Add `macos-latest` to the test matrix, bump job timeout to 20m, set `fail-fast: false` so one OS failing doesn't mask the other.
- Gate GUI-bound and slow chezmoi run_onchange scripts on `$CI` / `$GITHUB_ACTIONS`:
  - `configure-macos-preferences` — `osascript` / `killall Dock` / wallpaper need a GUI session
  - `install-nvim-plugins` — `Lazy! sync` is slow + network-heavy
  - `install-claude-code` — curl-pipe installer with no purpose in CI
  - `install-packages-darwin` — install brews (catches formula drift), skip casks (1Password, Slack, Cursor, VS Code, Ghostty, Loopback, etc. — GBs of downloads, some need GUI auth / licenses). Templated branch so the script body is shorter on CI.
- Workflow comment documents the skips.

## Notes for reviewers

- Verified locally before push: rendered every modified template with `chezmoi execute-template` in both CI=1 and non-CI modes; `bash -n` + `shellcheck` clean on all renderings; bats suite 35/35; `actionlint` + `zizmor` + `ghalint` clean on the workflow.
- Brew **casks** drift won't be caught — explicit tradeoff because the GUI cask installs would balloon the runner. If I want cask coverage later I can split a separate slow lane.
- The `lint` job stays ubuntu-only — lint rules are OS-agnostic and there's no reason to pay macOS minutes for them.