### PR TITLE
chore(hk): reconcile hk.pkl import with mise pin v1.45.0 :broom:

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.35.0/hk@1.35.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.35.0/hk@1.35.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
 local linters = new Mapping<String, Step|Group> {
   // Essential

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,8 @@
   enabledManagers: [
     'mise',
     'github-actions',
+    'custom.regex',
+    'custom.jsonata',
   ],
   lockFileMaintenance: {
     enabled: true,
@@ -53,6 +55,17 @@
         '^cosign\\s*=\\s*"(?<currentValue>v?[^"]+)"',
       ],
       depNameTemplate: 'sigstore/cosign',
+      datasourceTemplate: 'github-releases',
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^hk\\.pkl$/',
+      ],
+      matchStrings: [
+        'github\\.com/jdx/hk/releases/download/(?<currentValue>v[^/]+)/hk@[^#"]+',
+      ],
+      depNameTemplate: 'jdx/hk',
       datasourceTemplate: 'github-releases',
     },
     {


### PR DESCRIPTION
Closes #9.

## Why

`hk.pkl` hard-coded the v1.35.0 schema URLs while `mise.toml` pinned `hk = "1.45.0"`. The runtime hk binary was 10 minor versions ahead of the schema it consumed, and Renovate had no manager to keep them aligned.

## What

- `hk.pkl`: bump `amends` / `import` URLs from `v1.35.0` → `v1.45.0` (matches the mise pin).
- `renovate.json5`: add a `customManagers` regex entry for `github.com/jdx/hk/releases/download/vX.Y.Z/hk@X.Y.Z` with `datasource: github-releases`, `depName: jdx/hk`.
- `renovate.json5`: add `'custom.regex'` and `'custom.jsonata'` to `enabledManagers`. **This is the load-bearing change** — without it the previous list (`['mise', 'github-actions']`) silently disabled every `customManager` in this file, including the new hk one and ~50 existing entries (cosign, go-tools, node-tools, chezmoi externals, every LazyVim lazy-lock entry, tmux plugins). The new hk manager only fires once those are enabled.

## Notes for reviewers

- Verified locally: `pkl eval hk.pkl` loads cleanly against the v1.45.0 schema; `renovate-config-validator` is happy; the customManager regex matches both lines in `hk.pkl` and extracts `v1.45.0` as `currentValue`.
- **Heads up on PR volume:** turning custom managers on may produce a noticeable batch of Renovate PRs as it catches up on ~50 previously-dormant entries (LazyVim plugins especially). Existing `prHourlyLimit: 2` will pace them, but expect activity over the next few hours. If you'd rather stage that separately, say the word and I can split that line out.
- `hk check` locally hits a `gitleaks: command not found` (pre-existing — the user's mise has `betterleaks` instead). CI lint passes today, so this is a local-env quirk, not something the PR introduces.