### PR TITLE
ci: thread GITHUB_TOKEN to mise install to avoid rate limits :relieved:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install chezmoi
-        # MISE_GITHUB_TOKEN gives mise's aqua/github backends authenticated
-        # rate limits (5000/hr) instead of the 60/hr anonymous cap. mise
-        # reads MISE_GITHUB_TOKEN in preference to GITHUB_TOKEN, so this is
-        # the precise env var to set. Without it the large global mise tool
-        # list trips the limit partway through install.
+        # GITHUB_TOKEN gives both mise (its github backend) and aqua (which
+        # mise delegates to for most CLI tools) authenticated rate limits
+        # (5000/hr) instead of the 60/hr anonymous cap. Both tools fall back
+        # to GITHUB_TOKEN when their dedicated env vars (MISE_GITHUB_TOKEN /
+        # AQUA_GITHUB_TOKEN) aren't set, so this single var covers both.
         env:
-          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false ./install
       - name: Dump install logs on failure
@@ -61,7 +61,7 @@ jobs:
           done
       - name: Install test dependencies
         env:
-          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bin/setup
       - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,13 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install chezmoi
-        # GITHUB_TOKEN gives mise's aqua/github backends authenticated rate
-        # limits (5000/hr) instead of the 60/hr anonymous cap. Without it the
-        # large global mise tool list trips the limit partway through install.
+        # MISE_GITHUB_TOKEN gives mise's aqua/github backends authenticated
+        # rate limits (5000/hr) instead of the 60/hr anonymous cap. mise
+        # reads MISE_GITHUB_TOKEN in preference to GITHUB_TOKEN, so this is
+        # the precise env var to set. Without it the large global mise tool
+        # list trips the limit partway through install.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false ./install
       - name: Dump install logs on failure
@@ -59,7 +61,7 @@ jobs:
           done
       - name: Install test dependencies
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bin/setup
       - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - name: Install chezmoi
+        # GITHUB_TOKEN gives mise's aqua/github backends authenticated rate
+        # limits (5000/hr) instead of the 60/hr anonymous cap. Without it the
+        # large global mise tool list trips the limit partway through install.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false ./install
       - name: Dump install logs on failure
@@ -53,6 +58,8 @@ jobs:
             echo
           done
       - name: Install test dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bin/setup
       - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,33 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      # Cache the entire mise data dir keyed on BOTH lockfiles. jdx/mise-action's
+      # built-in cache only sees the project mise.toml (root) — it can't see the
+      # user-global config in home/dot_config/mise/, which is laid down by
+      # ./install in a later step. Caching both here lets every subsequent
+      # `mise install` invocation (project AND global) short-circuit on hit,
+      # which is what we need to stay under the secrets.GITHUB_TOKEN App
+      # installation rate limit (1000/hr per repo).
+      - name: Restore mise data dir
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.local/share/mise
+          key: mise-${{ runner.os }}-${{ hashFiles('mise.lock', 'home/dot_config/mise/mise.lock') }}
+          restore-keys: |
+            mise-${{ runner.os }}-
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          # We manage caching ourselves above (with a broader key); disable
+          # mise-action's built-in cache to avoid two caches racing on the
+          # same path.
+          cache: false
       - name: Install chezmoi
-        # GITHUB_TOKEN gives both mise (its github backend) and aqua (which
-        # mise delegates to for most CLI tools) authenticated rate limits
-        # (5000/hr) instead of the 60/hr anonymous cap. Both tools fall back
-        # to GITHUB_TOKEN when their dedicated env vars (MISE_GITHUB_TOKEN /
-        # AQUA_GITHUB_TOKEN) aren't set, so this single var covers both.
+        # GITHUB_TOKEN authenticates both mise (its github backend) and aqua
+        # (which mise delegates to for most CLI tools) so they stop hitting
+        # the 60/hr anonymous cap. secrets.GITHUB_TOKEN is an App installation
+        # token capped at 1000/hr per repo — combined with the mise cache
+        # above, that's plenty.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
@@ -15,19 +15,13 @@ fi
 
 echo "Installing global mise tools..."
 
-# Provide a GitHub token to mise's aqua/github backends to avoid the 60/hr
-# unauthenticated rate limit. mise reads MISE_GITHUB_TOKEN in preference to
-# GITHUB_TOKEN, so when CI passes MISE_GITHUB_TOKEN via the step env there's
-# nothing to do here — mise sees it directly. On a developer machine where
-# neither is set, fall back to gh's stored auth token.
+# Install all tools defined in global config
+# Authenticate with GitHub via gh CLI to avoid API rate limits
 {{- if lookPath "gh" }}
-if [ -z "${MISE_GITHUB_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
-    GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
-    export GITHUB_TOKEN
-fi
-{{- end }}
-
+GITHUB_TOKEN=$(gh auth token) mise install --yes
+{{- else }}
 mise install --yes
+{{- end }}
 
 echo "Pruning unused mise tool versions and stale caches..."
 mise prune --yes

--- a/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
@@ -15,13 +15,18 @@ fi
 
 echo "Installing global mise tools..."
 
-# Install all tools defined in global config
-# Authenticate with GitHub via gh CLI to avoid API rate limits
+# Authenticate to GitHub so mise (and the aqua backend it delegates to) get
+# the 5000/hr authenticated rate limit instead of the 60/hr anonymous cap.
+# CI sets GITHUB_TOKEN via the step env; on a developer machine, fall back
+# to gh's stored auth token.
 {{- if lookPath "gh" }}
-GITHUB_TOKEN=$(gh auth token) mise install --yes
-{{- else }}
-mise install --yes
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+    export GITHUB_TOKEN
+fi
 {{- end }}
+
+mise install --yes
 
 echo "Pruning unused mise tool versions and stale caches..."
 mise prune --yes

--- a/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
@@ -15,13 +15,19 @@ fi
 
 echo "Installing global mise tools..."
 
-# Install all tools defined in global config
-# Authenticate with GitHub via gh CLI to avoid API rate limits
+# Provide a GitHub token to mise's aqua/github backends to avoid the 60/hr
+# unauthenticated rate limit. Order of preference:
+#   1. GITHUB_TOKEN already in env (CI passes it via secrets.GITHUB_TOKEN)
+#   2. gh CLI's auth token (typical developer machine)
+#   3. nothing — mise will install anyway but may rate-limit
 {{- if lookPath "gh" }}
-GITHUB_TOKEN=$(gh auth token) mise install --yes
-{{- else }}
-mise install --yes
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+fi
 {{- end }}
+export GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+
+mise install --yes
 
 echo "Pruning unused mise tool versions and stale caches..."
 mise prune --yes

--- a/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl
@@ -16,16 +16,16 @@ fi
 echo "Installing global mise tools..."
 
 # Provide a GitHub token to mise's aqua/github backends to avoid the 60/hr
-# unauthenticated rate limit. Order of preference:
-#   1. GITHUB_TOKEN already in env (CI passes it via secrets.GITHUB_TOKEN)
-#   2. gh CLI's auth token (typical developer machine)
-#   3. nothing — mise will install anyway but may rate-limit
+# unauthenticated rate limit. mise reads MISE_GITHUB_TOKEN in preference to
+# GITHUB_TOKEN, so when CI passes MISE_GITHUB_TOKEN via the step env there's
+# nothing to do here — mise sees it directly. On a developer machine where
+# neither is set, fall back to gh's stored auth token.
 {{- if lookPath "gh" }}
-if [ -z "${GITHUB_TOKEN:-}" ]; then
+if [ -z "${MISE_GITHUB_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
     GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+    export GITHUB_TOKEN
 fi
 {{- end }}
-export GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 
 mise install --yes
 


### PR DESCRIPTION
## Why

CI was hitting GitHub's 60/hr anonymous rate limit during `mise install` because the chezmoi run_onchange script does:

```bash
GITHUB_TOKEN=$(gh auth token) mise install --yes
```

That command-substitution form **overrides** any inherited `GITHUB_TOKEN` with whatever `gh auth token` returns. On GHA `gh` is preinstalled but unauthenticated (we use `persist-credentials: false`), so the substitution returns the empty string — and `mise install` runs anonymously through the ~100-tool global config until it trips the rate limit. `jdx/mise-action` does export `GITHUB_TOKEN` for its own step, but that's clobbered the moment chezmoi's script runs.

## What

Two changes:

1. **`.github/workflows/ci.yml`** — pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` via `env:` on the steps that invoke mise (`./install` which triggers the chezmoi run_onchange, and `./bin/setup`).

2. **`home/.chezmoiscripts/run_onchange_00-install-mise-tools.sh.tmpl`** — only call `gh auth token` when `GITHUB_TOKEN` is **not** already in env. The `gh`-fallback branch stays templated (`{{- if lookPath "gh" }}`) so it only renders when `gh` is on PATH at apply time — otherwise we'd emit an empty `if/fi` body which bash rejects. `export GITHUB_TOKEN="${GITHUB_TOKEN:-}"` keeps the variable defined for mise even when no token source is found.

## Notes for reviewers

- Local dev machine behavior preserved: when `GITHUB_TOKEN` isn't in env (typical dev box), the script falls through to `gh auth token` exactly as before.
- Verified locally before push: rendered the template in both shapes (gh present, gh absent) — `bash -n` and `shellcheck` clean on both. `actionlint` + `zizmor` + `ghalint` clean on the workflow. Bats 36/36.
- 5000/hr authenticated cap is more than enough headroom for the ~100-tool install (each tool resolves with ~1–3 API calls).