### PR TITLE
fix(install): handle stale mise shims for chezmoi :bug:

### DIFF
--- a/install
+++ b/install
@@ -881,12 +881,20 @@ download_chezmoi() {
 
 # Function to install chezmoi
 install_chezmoi() {
-  # Check if chezmoi is already available and not forcing reinstall
-  if command -v chezmoi >/dev/null 2>&1 && [ "${REINSTALL_TOOLS:-false}" != "true" ]; then
+  # Check if chezmoi is already available AND functional. `command -v chezmoi`
+  # alone isn't enough: on CI, jdx/mise-action's built-in cache can restore a
+  # stale `chezmoi` shim under ~/.local/share/mise/shims/ from a prior run
+  # (where chezmoi was configured in the user-global mise config that doesn't
+  # exist yet on this run). The shim exists but has no version mapping, so
+  # `chezmoi --version` fails. Probe it before trusting it.
+  if command -v chezmoi >/dev/null 2>&1 && chezmoi --version >/dev/null 2>&1 && [ "${REINSTALL_TOOLS:-false}" != "true" ]; then
     log_info "Chezmoi is already installed: $(command -v chezmoi)"
     log_info "Version: $(chezmoi --version 2>/dev/null || echo "unknown")"
     log_info "Use REINSTALL_TOOLS=true to reinstall"
     return 0
+  fi
+  if command -v chezmoi >/dev/null 2>&1; then
+    log_info "Found non-functional chezmoi at $(command -v chezmoi) (likely a stale mise shim); falling through to install"
   fi
 
   # First, ensure cosign is available if signature verification is enabled
@@ -1000,7 +1008,25 @@ main() {
 
 	add_to_path
 
-	chezmoi_bin="$(command -v chezmoi)"
+	# Resolve a chezmoi binary that actually works. `command -v` may surface
+	# a stale mise shim (e.g. when CI's mise-action cache restores a shim
+	# from a prior run where the user-global mise config was active, but
+	# that config doesn't exist yet on this run). Probe `--version` and fall
+	# back to known install locations if the PATH-resolved one is broken.
+	chezmoi_bin="$(command -v chezmoi 2>/dev/null || true)"
+	if [ -z "$chezmoi_bin" ] || ! "$chezmoi_bin" --version >/dev/null 2>&1; then
+		[ -n "$chezmoi_bin" ] && log_info "chezmoi at $chezmoi_bin is non-functional (likely a stale mise shim); searching install locations"
+		for _cz_candidate in "$BIN_DIR/chezmoi" "/opt/homebrew/bin/chezmoi" "/usr/local/bin/chezmoi" "/home/linuxbrew/.linuxbrew/bin/chezmoi"; do
+			if [ -x "$_cz_candidate" ] && "$_cz_candidate" --version >/dev/null 2>&1; then
+				chezmoi_bin="$_cz_candidate"
+				break
+			fi
+		done
+	fi
+	if [ -z "$chezmoi_bin" ] || ! "$chezmoi_bin" --version >/dev/null 2>&1; then
+		log_error "Could not find a working chezmoi binary after installation"
+		exit 1
+	fi
 
 	log_info "Initializing dotfiles from $script_dir..."
 	log_info "Summary: Chezmoi available at $chezmoi_bin and configured successfully"


### PR DESCRIPTION
## Why

CI started failing across both Ubuntu and macOS with:

```
[INFO] Summary: Chezmoi available at /…/.local/share/mise/shims/chezmoi and configured successfully
mise ERROR No version is set for shim: chezmoi
Set a global default version with one of the following:
mise use -g aqua:twpayne/chezmoi@2.70.3
```

Trace:

1. `jdx/mise-action@v4` enables its built-in cache by default and restores `~/.local/share/mise` from a prior run.
2. On the prior run, `chezmoi apply` had laid down the user-global `~/.config/mise/config.toml` (which lists `aqua:twpayne/chezmoi`), so mise generated a `chezmoi` shim. That shim got cached.
3. On THIS run, the user-global config doesn't exist yet (we're about to apply chezmoi). The cached shim is restored, but it has no version mapping because the config that registers it isn't there yet → shim errors when invoked.
4. `install_chezmoi` does `command -v chezmoi`, finds the shim, sees the cached file exists, prints `Version: unknown` (the `chezmoi --version` failure was silently swallowed by `|| echo "unknown"`), and returns 0 thinking chezmoi is installed.
5. `main()` then `exec`s the shim → error → workflow fails.

## What

Two defensive changes in `install`:

1. **`install_chezmoi` early-return** now requires `chezmoi --version` to actually succeed (not just `command -v` to find a file). Falls through to the normal package-manager-then-download path otherwise.
2. **Post-install binary resolution in `main()`** probes `command -v chezmoi`'s `--version` and, if it fails, walks a list of known install locations (`$BIN_DIR`, `/opt/homebrew/bin`, `/usr/local/bin`, `/home/linuxbrew/.linuxbrew/bin`) to find a working binary. mise's shims dir comes earlier in the GHA `PATH` than any of those, so `command -v` alone isn't enough.

Both are no-ops in the happy path. They only branch when we've inherited a stale shim.

## Notes for reviewers

- Local verification: `shellcheck install` clean, `bash -n install` clean, bats 36/36.
- I considered also moving `$BIN_DIR` to the front of PATH in `add_to_path`, but that has broader blast radius (would shadow tools a user might intentionally have earlier in PATH on their dev box). The explicit-location fallback is more surgical.
- Doesn't address the upstream behavior of mise-action's cache restoring shims for tools that aren't in the current scope. If that becomes a recurring problem we can disable mise-action's cache and manage one explicitly (already drafted in a separate branch), but this fix makes `./install` robust regardless.