### PR TITLE
feat: dev tooling expansion (tmux, aichat, lazygit, worktrunk, curl)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
             mise-${{ runner.os }}-
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
         with:
           # We manage caching ourselves above (with a broader key); disable
           # mise-action's built-in cache to avoid two caches racing on the
@@ -67,7 +69,7 @@ jobs:
         # token capped at 1000/hr per repo — combined with the mise cache
         # above, that's plenty.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
         run: |
           GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false ./install
       - name: Dump install logs on failure
@@ -80,7 +82,7 @@ jobs:
           done
       - name: Install test dependencies
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
         run: |
           ./bin/setup
       - name: Run test suite

--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -1,11 +1,14 @@
 packages:
   darwin:
-    brews: 
+    brews:
       # Security & Auth
       - cosign
       - git-crypt
       - gnupg
       - ca-certificates
+
+      # AI Tools
+      - aichat
 
       # CLI Utilities
       - awscli
@@ -40,11 +43,11 @@ packages:
       - xz
       - zstd
 
-
       # Git & Version Control
       - gh
       - git
       - git-lfs
+      - worktrunk
 
       # Documentation & Visualization
       - mermaid-cli

--- a/home/.chezmoidata/tmux-plugins.yaml
+++ b/home/.chezmoidata/tmux-plugins.yaml
@@ -17,3 +17,8 @@ tmux_plugins:
       url: https://github.com/erikw/tmux-powerline.git
       revision: 6cddf8051823815db77fc00dcbb6bcca9afbdec2
       refreshPeriod: "168h"
+    - path: ".config/tmux/plugins/tmux-prefix-highlight"
+      type: git-repo
+      url: https://github.com/tmux-plugins/tmux-prefix-highlight
+      revision: 06cbb4ecd3a0a918ce355c70dc56d79debd455c7
+      refreshPeriod: "168h"

--- a/home/dot_config/aichat/config.yaml.tmpl
+++ b/home/dot_config/aichat/config.yaml.tmpl
@@ -1,4 +1,4 @@
 model: claude-haiku-4-5-20251001
 clients:
   - type: claude
-    api_key: {{ onepasswordRead "op://Private/Claude Dotfiles API Key/key" | trim }}
+    api_key: {{ if lookPath "op" }}{{ onepasswordRead "op://Private/Claude Dotfiles API Key/key" | trim }}{{ else }}placeholder{{ end }}

--- a/home/dot_config/aichat/config.yaml.tmpl
+++ b/home/dot_config/aichat/config.yaml.tmpl
@@ -1,0 +1,4 @@
+model: claude-haiku-4-5-20251001
+clients:
+  - type: claude
+    api_key: {{ onepasswordRead "op://Private/Claude Dotfiles API Key/key" | trim }}

--- a/home/dot_config/aichat/roles/commit.md
+++ b/home/dot_config/aichat/roles/commit.md
@@ -1,0 +1,21 @@
+---
+model: openai:gpt-5.4-mini
+temperature: 0.7
+---
+You are an expert at writing Git commits. Your job is to write a short clear commit message that summarizes the changes.
+
+If you can accurately express the change in just the subject line, don't include anything in the message body. Only use the body when it is providing *useful* information.
+
+Don't repeat information from the subject line in the message body.
+
+Only return the commit message in your response. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the commit message.
+
+Generate a conventional commit message in the format "type: summary".
+
+RULES:
+- Use conventional types: feat, fix, chore, docs, refactor, test, perf, build, ci, style, revert
+- Do NOT include a scope
+- Max 72 characters
+- Use imperative mood
+- Avoid trailing periods
+- No bullets, no numbering, no quotes

--- a/home/dot_config/curlrc
+++ b/home/dot_config/curlrc
@@ -1,0 +1,7 @@
+# https://curl.se/docs/manpage.html
+
+--create-dirs
+--fail
+--parallel
+--progress-bar
+--styled-output

--- a/home/dot_config/lazygit/config.yml.tmpl
+++ b/home/dot_config/lazygit/config.yml.tmpl
@@ -1,0 +1,18 @@
+git:
+  pagers:
+    - colorArg: always
+      pager: delta --dark --paging=never --line-numbers --true-color=always --hunk-header-style=omit
+
+customCommands:
+  - key: G
+    description: AI Commit
+    command: 'git commit -m "{{ "{{" }}.Form.Msg{{ "}}" }}"'
+    context: files
+    prompts:
+      - type: menuFromCommand
+        title: AI Commits
+        key: Msg
+        command: "~/.config/lazygit/aicommit.sh'"
+        filter: '^(?P<raw>.+)$'
+        valueFormat: "{{ "{{" }} .raw {{ "}}" }}"
+        labelFormat: "{{ "{{" }} .raw | green {{ "}}" }}"

--- a/home/dot_config/lazygit/executable_aicommit.sh
+++ b/home/dot_config/lazygit/executable_aicommit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+diff_content=$(git diff --cached)
+if [ -z "$diff_content" ]; then
+  echo "No staged changes" >&2
+  exit 1
+fi
+
+recent_commits=$(git log -n 6 --pretty=format:'%s' 2>/dev/null || true)
+
+prompt="Generate exactly 3 commit messages, one per line, no numbering, no bullets, no quotes.
+Each message should offer a different perspective on the changes.
+
+RECENT COMMITS (match this style):
+${recent_commits}
+
+CHANGES:
+${diff_content}"
+
+aichat -r commit -S -- "$prompt" 2>/dev/null |
+  awk 'NF { gsub(/^[0-9]+[.)]\s*/, ""); print; count++ } count==3 { exit }'

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -22,7 +22,7 @@ experimental = true
 lockfile = true
 pin = true
 env_file = ".env" # load env varsr from a dotenv file, see `MISE_ENV_FILE`
-disable_backends = ["asdf", "ubi", "vfox", "dotnet"]
+disable_backends = ["asdf", "vfox", "dotnet"]
 disable_tools = ["java"]
 
 [settings.python]
@@ -93,8 +93,9 @@ fnox    = "latest"
 "aqua:jdx/hk"                   = "latest" # git hooks and project lints
 "github:modem-dev/hunk"         = { version = "latest", bin = "hunk" } # Review-first terminal diff viewer for agentic coders
 "github:gitui-org/gitui"        = "latest" # Blazing 💥 fast terminal-ui for git written in rust 🦀
-"github:max-sixty/worktrunk"    = "latest" # Git worktree management, designed for parallel AI agent workflows
-"github:jesseduffield/lazygit"  = "latest" # Terminal UI for Git
+"github:max-sixty/worktrunk"      = "latest" # Git worktree management, designed for parallel AI agent workflows
+"github:jesseduffield/lazygit"    = "latest" # Terminal UI for Git
+"ubi:miltonparedes/kitmux"        = "0.1.0-rc.1" # tmux command palette for projects, sessions, and worktrees
 "npm:commitizen"                = "latest" # commit message utility
 "npm:cz-conventional-changelog" = "latest" # Generate a CHANGELOG from git metadata.
 

--- a/home/dot_config/mise/mise.lock
+++ b/home/dot_config/mise/mise.lock
@@ -1598,3 +1598,10 @@ backend = "core:ruby"
 [[tools.rust]]
 version = "1.95.0"
 backend = "core:rust"
+
+[[tools."ubi:miltonparedes/kitmux"]]
+version = "0.1.0-rc.1"
+backend = "ubi:miltonparedes/kitmux"
+
+[tools."ubi:miltonparedes/kitmux"."platforms.macos-arm64-kitmux"]
+checksum = "blake3:7e32aa2b6317b07ffc7b595604dcd31ad26cee881dee706540f6213bc10f1532"

--- a/home/dot_config/tmux/executable_tmux-remote-detect.sh
+++ b/home/dot_config/tmux/executable_tmux-remote-detect.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Detect if current session is accessed via SSH
+# Sets @is-remote user option for conditional status bar formatting
+
+if tmux show-environment SSH_CONNECTION 2>/dev/null | grep -q '^SSH_CONNECTION='; then
+  tmux set -g @is-remote 1
+else
+  tmux set -g @is-remote 0
+fi

--- a/home/dot_config/tmux/tmux.conf
+++ b/home/dot_config/tmux/tmux.conf
@@ -7,6 +7,7 @@
 # ---------------------------------------------------------------------------
 # Load tmux-sensible first — provides sane defaults we build on
 run-shell ~/.config/tmux/plugins/tmux-sensible/sensible.tmux
+run-shell ~/.config/tmux/plugins/tmux-prefix-highlight/prefix_highlight.tmux
 
 # ---------------------------------------------------------------------------
 # Terminal & Display
@@ -17,6 +18,8 @@ set -ga terminal-overrides ",xterm-256color:Tc,xterm-ghostty:Tc"
 # Disable extended-keys to fix paste in Ghostty + neovim
 # See: https://github.com/gpakosz/.tmux/issues/776
 set -s extended-keys off
+# Allow escape sequences to pass through to terminal (for images, etc)
+set -g allow-passthrough on
 
 # ---------------------------------------------------------------------------
 # Prefix
@@ -39,6 +42,18 @@ set -g mouse on
 setw -g mode-keys vi
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
+
+# `on` lets tmux both keep its own buffer AND forward the OSC 52 sequence
+# to the outer terminal (vs. `external` which skips tmux's own buffer).
+# Requires tmux >= 3.2.
+set -g set-clipboard on
+# Advertise OSC 52 support (`Ms`) so tmux actually emits the sequence even
+# when the outer TERM is not in its builtin whitelist. Needed for ghostty,
+# wezterm, kitty, alacritty, iTerm2, foot, etc. Requires tmux >= 3.2.
+set -as terminal-features ",*:clipboard"
+set -as terminal-features ",xterm*:clipboard"
+set -as terminal-features ",tmux-256color:clipboard"
+set -as terminal-features ",ghostty:clipboard"
 
 # ---------------------------------------------------------------------------
 # Smart pane switching with awareness of Vim splits
@@ -77,6 +92,12 @@ bind -r J resize-pane -D 5
 bind -r K resize-pane -U 5
 bind -r L resize-pane -R 5
 
+# Arrows without repeat
+bind Up select-pane -U
+bind Left select-pane -L
+bind Down select-pane -D
+bind Right select-pane -R
+
 # ---------------------------------------------------------------------------
 # Utility bindings
 # ---------------------------------------------------------------------------
@@ -89,6 +110,8 @@ bind - split-window -v -c "#{pane_current_path}"
 
 # New window (preserve PWD)
 bind c new-window -c "#{pane_current_path}"
+bind -n C-Tab next-window
+bind -n C-S-Tab previous-window
 
 # Reload config
 bind r source-file ~/.config/tmux/tmux.conf \; display-message "Config reloaded"
@@ -98,6 +121,43 @@ bind w choose-tree -Zw
 
 # Open Claude Code in chezmoi directory
 bind e run-shell 'tmux new-window -c "$(chezmoi data | jq -r .chezmoi.workingTree)" -n "dotfiles" "claude"'
+
+bind q detach-client
+bind z run-shell "zed #{pane_current_path}"
+
+# ---------------------------------------------------------------------------
+# Keybindings: Sessions
+# ---------------------------------------------------------------------------
+unbind s
+bind -n M-s display-popup -w 50% -h 60% -E "kitmux sessions"
+bind -n M-k display-popup -w 50% -h 40% -E "kitmux palette"
+bind -n M-j display-popup -d "#{pane_current_path}" -w 80% -h 80%
+bind o display-popup -w 50% -h 60% -E "kitmux workspaces"
+bind W display-popup -w 50% -h 80% -E "kitmux worktrees"
+bind A display-popup -w 40% -h 60% -E "kitmux agents"
+
+# ---------------------------------------------------------------------------
+# Keybindings: Popups
+# ---------------------------------------------------------------------------
+bind p display-popup -d "#{pane_current_path}" -w 80% -h 80%
+bind g display-popup -d "#{pane_current_path}" -w 100% -h 100% -E "lazygit"
+bind v display-popup -d "#{pane_current_path}" -w 100% -h 100% -E "nvim"
+bind d display-popup -d "#{pane_current_path}" -x C -y C -w 100% -h 100% -E "lumen diff"
+bind D display-popup -d "#{pane_current_path}" -x C -y C -w 100% -h 100% -E "fish -c lumen-stacked"
+bind y run-shell 'tmux new-window -c "#{pane_current_path}" yazi'
+
+# Popup styling (tmux 3.3+)
+set -g popup-border-style "fg=#5b5b5b"
+set -g popup-border-lines single
+
+# ---------------------------------------------------------------------------
+# Remote Session Detection
+# ---------------------------------------------------------------------------
+set -g update-environment "SSH_CONNECTION SSH_CLIENT SSH_TTY DISPLAY TERM TERM_PROGRAM"
+run-shell '~/.config/tmux/tmux-remote-detect.sh'
+set-hook -g client-attached 'run-shell "~/.config/tmux/tmux-remote-detect.sh"'
+set-hook -g session-created 'run-shell "~/.config/tmux/tmux-remote-detect.sh"'
+
 
 # ---------------------------------------------------------------------------
 # Pane styling (Catppuccin — appearance-aware)

--- a/home/dot_config/worktrunk/config.toml
+++ b/home/dot_config/worktrunk/config.toml
@@ -1,0 +1,256 @@
+# Worktrunk Configuration
+#
+# Create with `wt config create`
+#
+# Location:
+#
+# - macOS/Linux: `~/.config/worktrunk/config.toml` (or `$XDG_CONFIG_HOME` if set)
+# - Windows: `%APPDATA%\worktrunk\config.toml`
+#
+# Worktree path template
+#
+# Controls where new worktrees are created. Paths are relative to the repository root.
+#
+# **Variables:**
+#
+# - `{{ repo }}` — repository directory name
+# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
+# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
+# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
+#
+# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
+#
+# # Default — siblings in parent directory
+# # Creates: ~/code/myproject.feature-auth
+# worktree-path = "../{{ repo }}.{{ branch | sanitize }}"
+#
+# # Inside the repository
+# # Creates: ~/code/myproject/.worktrees/feature-auth
+# worktree-path = ".worktrees/{{ branch | sanitize }}"
+#
+# # Namespaced (useful when multiple repos share a parent directory)
+# # Creates: ~/code/worktrees/myproject/feature-auth
+# worktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"
+#
+# # Nested bare repo (git clone --bare <url> project/.git)
+# # Creates: ~/code/project/feature-auth (sibling to .git)
+# worktree-path = "../{{ branch | sanitize }}"
+#
+# ## LLM commit messages
+#
+# Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+#
+# Using [llm](https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
+#
+# [commit-generation]
+# command = "llm"
+# args = ["-m", "claude-haiku-4.5"]
+#
+# Using [aichat](https://github.com/sigoden/aichat):
+#
+[commit.generation]
+command = "aichat"
+args = ["-m", "openai:gpt-5.4-mini", "-S"]
+template = """
+Generate a conventional commit message in the format "type: summary".
+
+RULES:
+- Use conventional types: feat, fix, chore, docs, refactor, test, perf, build, ci, style, revert
+- Do NOT include a scope
+- Subject max 72 characters, imperative mood, no trailing period
+- Only return the commit message, no quotes, no code blocks
+- Only include a body if it adds useful information not in the subject
+- Don't repeat the subject in the body
+
+<diffstat>
+{{ git_diff_stat }}
+</diffstat>
+
+<diff>
+{{ git_diff }}
+</diff>
+
+<context>
+Branch: {{ branch }}
+{% if recent_commits %}<recent_commits>
+{% for commit in recent_commits %}- {{ commit }}
+{% endfor %}</recent_commits>{% endif %}
+</context>
+"""
+squash-template = """
+Combine these commits into a single conventional commit message in the format "type: summary".
+
+RULES:
+- Use conventional types: feat, fix, chore, docs, refactor, test, perf, build, ci, style, revert
+- Do NOT include a scope
+- Subject max 72 characters, imperative mood, no trailing period
+- Only return the commit message, no quotes, no code blocks
+- Only include a body if it adds useful information not in the subject
+
+<commits branch="{{ branch }}" target="{{ target_branch }}">
+{% for commit in commits %}- {{ commit }}
+{% endfor %}</commits>
+
+<diffstat>
+{{ git_diff_stat }}
+</diffstat>
+
+<diff>
+{{ git_diff }}
+</diff>
+"""
+#
+# See [Custom prompt templates](#custom-prompt-templates) for inline template options.
+#
+# ## Commands
+#
+# ### List
+#
+# Persistent flag values for `wt list`. Override on command line as needed.
+#
+# [list]
+# full = false       # Show CI status and main…± diffstat columns (--full)
+# branches = false   # Include branches without worktrees (--branches)
+# remotes = false    # Include remote-only branches (--remotes)
+#
+# ### Commit
+#
+# Shared by `wt step commit`, `wt step squash`, and `wt merge`.
+#
+# [commit]
+# stage = "all"      # What to stage before commit: "all", "tracked", or "none"
+#
+# ### Merge
+#
+# All flags are on by default. Set to false to change default behavior.
+#
+# [merge]
+# squash = true      # Squash commits into one (--no-squash to preserve history)
+# commit = true      # Commit uncommitted changes first (--no-commit to skip)
+# rebase = true      # Rebase onto target before merge (--no-rebase to skip)
+# remove = true      # Remove worktree after merge (--no-remove to keep)
+# verify = true      # Run project hooks (--no-verify to skip)
+#
+# ### Select
+#
+# Pager behavior for `wt select` diff previews.
+#
+# [select]
+# # Pager command with flags for diff preview (overrides git's core.pager)
+# # Use this to specify pager flags needed for non-TTY contexts
+# # Example:
+# # pager = "delta --paging=never"
+#
+# ### Approved commands
+#
+# Commands approved for project hooks. Auto-populated when approving hooks on first run, or via `wt hook approvals add`.
+#
+# [projects."github.com/user/repo"]
+# approved-commands = ["npm ci", "npm test"]
+#
+# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see <https://worktrunk.dev/hook/>.
+#
+# ### Custom prompt templates
+#
+# Templates use [minijinja](https://docs.rs/minijinja/) syntax.
+#
+# #### Commit template
+#
+# Available variables:
+#
+# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
+# - `{{ branch }}`, `{{ repo }}` — context
+# - `{{ recent_commits }}` — recent commit messages
+#
+# Default template:
+#
+# <!-- DEFAULT_TEMPLATE_START -->
+# [commit-generation]
+# template = """
+# Write a commit message for the staged changes below.
+#
+# <format>
+# - Subject under 50 chars, blank line, then optional body
+# - Output only the commit message, no quotes or code blocks
+# </format>
+#
+# <style>
+# - Imperative mood: "Add feature" not "Added feature"
+# - Match recent commit style (conventional commits if used)
+# - Describe the change, not the intent or benefit
+# </style>
+#
+# <diffstat>
+# {{ git_diff_stat }}
+# </diffstat>
+#
+# <diff>
+# {{ git_diff }}
+# </diff>
+#
+# <context>
+# Branch: {{ branch }}
+# {% if recent_commits %}<recent_commits>
+# {% for commit in recent_commits %}- {{ commit }}
+# {% endfor %}</recent_commits>{% endif %}
+# </context>
+#
+# """
+# <!-- DEFAULT_TEMPLATE_END -->
+#
+# #### Squash template
+#
+# Available variables (in addition to commit template variables):
+#
+# - `{{ commits }}` — list of commits being squashed
+# - `{{ target_branch }}` — merge target branch
+#
+# Default template:
+#
+# <!-- DEFAULT_SQUASH_TEMPLATE_START -->
+# [commit-generation]
+# squash-template = """
+# Combine these commits into a single commit message.
+#
+# <format>
+# - Subject under 50 chars, blank line, then optional body
+# - Output only the commit message, no quotes or code blocks
+# </format>
+#
+# <style>
+# - Imperative mood: "Add feature" not "Added feature"
+# - Match the style of commits being squashed (conventional commits if used)
+# - Describe the change, not the intent or benefit
+# </style>
+#
+# <commits branch="{{ branch }}" target="{{ target_branch }}">
+# {% for commit in commits %}- {{ commit }}
+# {% endfor %}</commits>
+#
+# <diffstat>
+# {{ git_diff_stat }}
+# </diffstat>
+#
+# <diff>
+# {{ git_diff }}
+# </diff>
+#
+# """
+# <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+
+# Create a tmux session with 2 vertical panes for each worktree
+[post-switch]
+tmux-session = """
+SESSION="{{ repo }}-{{ branch | sanitize }}"
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+  echo "tmux session '$SESSION' already exists"
+else
+  tmux new-session -d -s "$SESSION" -c "{{ worktree_path }}"
+  tmux split-window -h -t "$SESSION" -c "{{ worktree_path }}"
+  tmux select-layout -t "$SESSION" even-horizontal
+  echo "Created tmux session: $SESSION (2 vertical panes)"
+fi
+if [ -n "${TMUX:-}" ]; then
+  tmux switch-client -t "$SESSION"
+fi
+"""


### PR DESCRIPTION
## Summary

A bundle of related dev-tooling additions:

- **tmux** — adds `tmux-prefix-highlight`, OSC 52 clipboard passthrough for modern terminals (ghostty, wezterm, kitty), kitmux-driven popups for sessions/workspaces/worktrees/agents, popups for lazygit/nvim/yazi, and SSH remote-session detection for conditional status bar styling.
- **aichat** — base config (Claude API key sourced from 1Password) plus a `commit` role used by lazygit and worktrunk.
- **lazygit** — binds `G` to a menu of three AI-suggested commit messages generated from the staged diff and recent commit style; delta as pager.
- **worktrunk** — aichat-backed commit/squash message generation and a post-switch hook that creates a tmux session with two vertical panes per worktree.
- **curl** — sensible defaults (`--fail`, `--parallel`, `--progress-bar`, `--styled-output`, `--create-dirs`).
- **packages** — `aichat` + `worktrunk` brews required by the above.

## Test plan

- [ ] `chezmoi diff` shows only the expected additions/modifications
- [ ] `chezmoi apply` succeeds (1Password unlocked for aichat config render)
- [ ] `brew install aichat worktrunk` runs cleanly (or already present)
- [ ] Reload tmux config (`prefix + r`) — prefix highlight visible, popups bound to expected keys
- [ ] OSC 52 yank from tmux copies to outer terminal clipboard
- [ ] `lazygit` → `G` produces 3 commit message suggestions from a staged diff
- [ ] `wt` (worktrunk) generates a commit message on commit/squash
- [ ] BATS suite still passes: `./bin/test`