### PR TITLE
test(chezmoi): BATS coverage for macos-preferences and claude-settings :sparkles:

### DIFF
--- a/test/run_onchange_configure-macos-preferences.bats
+++ b/test/run_onchange_configure-macos-preferences.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+SCRIPT_FILE="home/.chezmoiscripts/run_onchange_configure-macos-preferences.sh.tmpl"
+
+darwin_config() {
+  local work_profile="${1:-false}"
+  cat >"$TEST_TMPDIR/darwin-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    work_profile = $work_profile
+EOF
+  printf '%s\n' "$TEST_TMPDIR/darwin-config.toml"
+}
+
+@test "does not render on non-darwin systems" {
+  cat >"$TEST_TMPDIR/linux-config.toml" <<EOF
+[data]
+    chezmoi = { os = "linux", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    work_profile = false
+EOF
+
+  run chezmoi execute-template --config "$TEST_TMPDIR/linux-config.toml" --file "$SCRIPT_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "renders a valid shell script on darwin" {
+  local config
+  config=$(darwin_config false)
+
+  run chezmoi execute-template --config "$config" --file "$SCRIPT_FILE"
+  [ "$status" -eq 0 ]
+  assert_script_structure "$output"
+  assert_valid_shell "$output"
+}
+
+@test "rendered script contains all expected preference sections" {
+  local config
+  config=$(darwin_config false)
+
+  run chezmoi execute-template --config "$config" --file "$SCRIPT_FILE"
+  [ "$status" -eq 0 ]
+
+  # Each managed preference should be present
+  [[ "$output" == *"AppleSymbolicHotKeys"* ]]
+  [[ "$output" == *"com.raycast.macos"* ]]
+  [[ "$output" == *"Monterey Graphic"* ]]
+  [[ "$output" == *"KeyRepeat"* ]]
+  [[ "$output" == *"AppleKeyboardUIMode"* ]]
+  [[ "$output" == *"closeViewScrollWheelToggle"* ]]
+  [[ "$output" == *"com.apple.dock"* ]]
+  [[ "$output" == *"VisibleCC Bluetooth"* ]]
+}
+
+@test "rendered script has CI skip guard" {
+  local config
+  config=$(darwin_config false)
+
+  run chezmoi execute-template --config "$config" --file "$SCRIPT_FILE"
+  [ "$status" -eq 0 ]
+  # shellcheck disable=SC2016 # matching literal shell syntax in rendered output
+  [[ "$output" == *'${CI:-}'* ]]
+  # shellcheck disable=SC2016 # matching literal shell syntax in rendered output
+  [[ "$output" == *'${GITHUB_ACTIONS:-}'* ]]
+  [[ "$output" == *"Running in CI, skipping macOS preferences"* ]]
+}
+
+@test "rendered output is identical for work_profile=true and work_profile=false" {
+  local work_config personal_config
+
+  work_config=$(darwin_config true)
+  personal_config=$(darwin_config false)
+
+  chezmoi execute-template --config "$work_config" --file "$SCRIPT_FILE" >"$TEST_TMPDIR/work.sh"
+  chezmoi execute-template --config "$personal_config" --file "$SCRIPT_FILE" >"$TEST_TMPDIR/personal.sh"
+
+  run diff "$TEST_TMPDIR/work.sh" "$TEST_TMPDIR/personal.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "re-rendering produces identical output (template idempotence)" {
+  local config
+  config=$(darwin_config false)
+
+  chezmoi execute-template --config "$config" --file "$SCRIPT_FILE" >"$TEST_TMPDIR/run1.sh"
+  chezmoi execute-template --config "$config" --file "$SCRIPT_FILE" >"$TEST_TMPDIR/run2.sh"
+
+  run diff "$TEST_TMPDIR/run1.sh" "$TEST_TMPDIR/run2.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "executing rendered script with CI=true exits cleanly without writing defaults" {
+  local config rendered
+  config=$(darwin_config false)
+  rendered="$TEST_TMPDIR/configure-macos-preferences.sh"
+
+  chezmoi execute-template --config "$config" --file "$SCRIPT_FILE" >"$rendered"
+  chmod +x "$rendered"
+
+  # Stub defaults/plutil/osascript/killall: if the CI guard works,
+  # none of these should be invoked. Each stub fails loudly if called.
+  cat >"$TEST_TMPDIR/defaults" <<'EOF'
+#!/usr/bin/env bash
+echo "defaults called with: $*" >&2
+exit 99
+EOF
+  cp "$TEST_TMPDIR/defaults" "$TEST_TMPDIR/plutil"
+  cp "$TEST_TMPDIR/defaults" "$TEST_TMPDIR/osascript"
+  cp "$TEST_TMPDIR/defaults" "$TEST_TMPDIR/killall"
+  chmod +x "$TEST_TMPDIR/defaults" "$TEST_TMPDIR/plutil" "$TEST_TMPDIR/osascript" "$TEST_TMPDIR/killall"
+
+  run env CI=true PATH="$TEST_TMPDIR:$PATH" bash "$rendered"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Running in CI, skipping macOS preferences"* ]]
+}

--- a/test/sync-claude-settings.bats
+++ b/test/sync-claude-settings.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+TEMPLATE_FILE="home/.chezmoiscripts/run_onchange_sync-claude-settings.sh.tmpl"
+SYNC_SCRIPT="bin/sync-claude-settings"
+
+template_config() {
+  local work_profile="${1:-false}"
+  cat >"$TEST_TMPDIR/sync-config.toml" <<EOF
+[data]
+    chezmoi = { os = "linux", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR", workingTree = "$PWD" }
+    work_profile = $work_profile
+EOF
+  printf '%s\n' "$TEST_TMPDIR/sync-config.toml"
+}
+
+run_sync() {
+  env HOME="$TEST_HOME_DIR" bash "$SYNC_SCRIPT"
+}
+
+@test "template renders to valid shell" {
+  local config
+  config=$(template_config false)
+
+  run chezmoi execute-template --config "$config" --file "$TEMPLATE_FILE"
+  [ "$status" -eq 0 ]
+  assert_script_structure "$output"
+  assert_valid_shell "$output"
+}
+
+@test "template invokes bin/sync-claude-settings" {
+  local config
+  config=$(template_config false)
+
+  run chezmoi execute-template --config "$config" --file "$TEMPLATE_FILE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bin/sync-claude-settings"* ]]
+}
+
+@test "template output is identical for work_profile=true and work_profile=false" {
+  local work_config personal_config
+
+  work_config=$(template_config true)
+  personal_config=$(template_config false)
+
+  chezmoi execute-template --config "$work_config" --file "$TEMPLATE_FILE" >"$TEST_TMPDIR/work.sh"
+  chezmoi execute-template --config "$personal_config" --file "$TEMPLATE_FILE" >"$TEST_TMPDIR/personal.sh"
+
+  run diff "$TEST_TMPDIR/work.sh" "$TEST_TMPDIR/personal.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "creates settings.json with required keys in a fresh HOME" {
+  run run_sync
+  [ "$status" -eq 0 ]
+
+  local settings="$TEST_HOME_DIR/.claude/settings.json"
+  [ -f "$settings" ]
+
+  # Valid JSON
+  run jq empty "$settings"
+  [ "$status" -eq 0 ]
+
+  # Required top-level keys set by the script
+  run jq -e '.statusLine.command' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.permissions.allow | length > 0' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.hooks.PreToolUse | length > 0' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.hooks.PostToolUse | length > 0' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS == "1"' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.model' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.extraKnownMarketplaces."pickled-claude-plugins"' "$settings"
+  [ "$status" -eq 0 ]
+}
+
+@test "creates a backup before mutating settings" {
+  run run_sync
+  [ "$status" -eq 0 ]
+
+  [ -f "$TEST_HOME_DIR/.claude/settings.json.bak" ]
+}
+
+@test "preserves unrelated user keys in existing settings.json" {
+  mkdir -p "$TEST_HOME_DIR/.claude"
+  cat >"$TEST_HOME_DIR/.claude/settings.json" <<'EOF'
+{
+  "theme": "dark",
+  "customUserKey": {"a": 1, "b": [2, 3]}
+}
+EOF
+
+  run run_sync
+  [ "$status" -eq 0 ]
+
+  local settings="$TEST_HOME_DIR/.claude/settings.json"
+  run jq -e '.theme == "dark"' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.customUserKey.a == 1' "$settings"
+  [ "$status" -eq 0 ]
+  run jq -e '.customUserKey.b == [2, 3]' "$settings"
+  [ "$status" -eq 0 ]
+}
+
+@test "does not touch settings.local.json" {
+  mkdir -p "$TEST_HOME_DIR/.claude"
+  cat >"$TEST_HOME_DIR/.claude/settings.local.json" <<'EOF'
+{"localOverride": "machine-specific", "secret": "do-not-touch"}
+EOF
+  local before_hash
+  before_hash=$(shasum "$TEST_HOME_DIR/.claude/settings.local.json" | awk '{print $1}')
+
+  run run_sync
+  [ "$status" -eq 0 ]
+
+  local after_hash
+  after_hash=$(shasum "$TEST_HOME_DIR/.claude/settings.local.json" | awk '{print $1}')
+  [ "$before_hash" = "$after_hash" ]
+}
+
+@test "is idempotent across consecutive runs" {
+  run run_sync
+  [ "$status" -eq 0 ]
+
+  # Capture stable subset (excluding fields the script might re-resolve)
+  local first_hash
+  first_hash=$(jq -S 'del(.env.ANTHROPIC_MODEL, .env.ANTHROPIC_DEFAULT_HAIKU_MODEL, .env.ANTHROPIC_DEFAULT_SONNET_MODEL, .env.ANTHROPIC_DEFAULT_OPUS_MODEL)' \
+    "$TEST_HOME_DIR/.claude/settings.json" | shasum | awk '{print $1}')
+
+  run run_sync
+  [ "$status" -eq 0 ]
+
+  local second_hash
+  second_hash=$(jq -S 'del(.env.ANTHROPIC_MODEL, .env.ANTHROPIC_DEFAULT_HAIKU_MODEL, .env.ANTHROPIC_DEFAULT_SONNET_MODEL, .env.ANTHROPIC_DEFAULT_OPUS_MODEL)' \
+    "$TEST_HOME_DIR/.claude/settings.json" | shasum | awk '{print $1}')
+
+  [ "$first_hash" = "$second_hash" ]
+}


### PR DESCRIPTION
## Why

Closes #15.

`configure-macos-preferences` and `sync-claude-settings` were the two highest-risk `run_onchange_*` scripts with no BATS coverage: one writes to user defaults, the other mutates `~/.claude/settings.json` — the file this agent itself depends on. Regressions in either are easy to miss locally.

## What

Two new BATS files patterned after `run_onchange_install-packages-darwin.bats`:

**`test/run_onchange_configure-macos-preferences.bats`** (7 tests)
- Renders to empty on non-darwin, valid shell on darwin
- All expected preference sections present (Spotlight, Raycast, wallpaper, KeyRepeat, keyboard nav, scroll zoom, Dock, Bluetooth)
- CI skip guard literally present in rendered output
- Output identical for `work_profile=true` vs `false` (script doesn't branch on it)
- Re-rendering produces byte-identical output
- **Linux-CI-friendly behavior test**: executes the rendered script with `CI=true` under stubs for `defaults`/`plutil`/`osascript`/`killall` that fail loudly if invoked — proves the CI guard short-circuits before any mutation

**`test/sync-claude-settings.bats`** (8 tests)
- Template renders to valid shell and invokes `bin/sync-claude-settings`
- Template output identical for `work_profile=true` vs `false`
- Drives the real `bin/sync-claude-settings` under an isolated `HOME=$TEST_HOME_DIR`:
  - Fresh HOME: produces `settings.json` with required keys (`statusLine`, `permissions.allow`, `hooks.{Pre,Post}ToolUse`, `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`, `model`, `extraKnownMarketplaces.pickled-claude-plugins`)
  - Pre-existing user keys (`theme`, `customUserKey`) survive the jq merge
  - `settings.local.json` is never touched (verified by shasum before/after)
  - `.bak` is created before mutation
  - Idempotent across consecutive runs (stable hash on the non-bedrock subset)

## Notes for reviewers

- The `sync-claude-settings` behavior tests take the **non-bedrock** branch because `chezmoi data` returns no `claude.use_bedrock` under an isolated HOME. That's the same branch a fresh-checkout CI install hits, so the test exercises the real CI codepath.
- The macOS preferences behavior test is intentionally Linux-friendly: it forces `chezmoi.os = darwin` to render the body, then proves the guard fires before any darwin-only command runs. No `defaults`/`osascript` shim drift to worry about.
- New tests bring total BATS count from 36 → 51, all green locally.

## Test plan

- [x] `./bin/test` passes locally (51 tests)
- [x] `shellcheck` clean on both new files
- [x] `shfmt -d` clean on both new files
- [ ] CI green on ubuntu-latest
- [ ] CI green on macos-latest