### PR TITLE
chore(mise): add ci:lint, ci:test, ci:all tasks for local CI simulation :sparkles:

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -19,3 +19,17 @@ run = "hk fix"
 [tasks.test]
 description = "Run test suite"
 run = "bats test/"
+
+[tasks."ci:lint"]
+description = "Run lint as CI does (hk check, not hk fix)"
+run = "hk check"
+env = { CI = "true", GITHUB_ACTIONS = "true" }
+
+[tasks."ci:test"]
+description = "Run tests as CI does (with CI and GITHUB_ACTIONS set)"
+run = "bats test/"
+env = { CI = "true", GITHUB_ACTIONS = "true" }
+
+[tasks."ci:all"]
+description = "Run the full CI shape locally (lint + test, no install)"
+depends = ["ci:lint", "ci:test"]


### PR DESCRIPTION
## Why

Closes #19.

Chezmoi templates and `run_onchange_*` scripts branch on `$CI` / `$GITHUB_ACTIONS`, so `./bin/test` exercises the dev-machine render path while CI exercises the CI render path. PR #17 hit exactly this — green locally, red on Ubuntu — because the bats env diverged from CI's.

## What

Three new mise tasks, leaves existing `lint` / `test` alone for the inner dev loop:

```
mise run ci:lint   # hk check (not hk fix) with CI=true GITHUB_ACTIONS=true
mise run ci:test   # bats test/ with CI=true GITHUB_ACTIONS=true
mise run ci:all    # depends on both
```

Verified locally:
- `mise tasks` lists all three with descriptions
- `mise tasks info ci:test` shows env vars are attached to the task definition (not just inherited)
- `mise run ci:test` runs all 51 bats with the CI env vars present
- `ci:all`'s `depends = ["ci:lint", "ci:test"]` chain shows up in `mise tasks info ci:all`

## Notes for reviewers

- `ci:test` uses `bats test/` to mirror the existing `test` task. `./bin/test` uses `bats ./**/*.bats`, but they resolve to the same set since all bats live in `test/`.
- `ci:lint` uses `hk check`, not `hk fix`, to match CI's failure mode (report-don't-fix). The existing `lint` task stays on `hk fix` for the dev loop.
- Did not reproduce the full `./install` + `chezmoi apply` flow — that's the slow CI path, and the issue scopes it out.

## Test plan

- [x] `mise tasks` lists `ci:lint`, `ci:test`, `ci:all`
- [x] `mise tasks info ci:test` shows `CI=true GITHUB_ACTIONS=true` attached
- [x] `mise run ci:test` runs the full bats suite
- [x] Existing `mise run lint` and `mise run test` unchanged
- [x] CI green (no code paths touched, but the mise.toml change loads on every CI run)