### PR TITLE
fix(hooks): scope enforce-source-dir.sh to actually managed paths :relieved:

### DIFF
--- a/.claude/hooks/enforce-source-dir.sh
+++ b/.claude/hooks/enforce-source-dir.sh
@@ -40,20 +40,24 @@ resolve_path() {
   fi
 }
 
-# Check if a resolved path is under $HOME but NOT under $CLAUDE_PROJECT_DIR
-# and NOT under ~/.claude (Claude Code's own workspace: plans, memory, settings)
-is_home_not_project() {
+# Check if a resolved path is a chezmoi-managed destination we should protect.
+# Fast-path filters first (paths outside $HOME, inside the project source, or
+# under ~/.claude can never be managed destinations), then ask chezmoi
+# directly so we don't over-trigger on unrelated repos that happen to live
+# under $HOME (e.g. ~/src/...).
+is_chezmoi_managed() {
   local resolved="$1"
-  [[ "$resolved" == "$HOME"/* ]] \
-    && [[ "$resolved" != "$CLAUDE_PROJECT_DIR"/* ]] \
-    && [[ "$resolved" != "$HOME/.claude"/* ]]
+  [[ "$resolved" == "$HOME"/* ]] || return 1
+  [[ "$resolved" == "$CLAUDE_PROJECT_DIR"/* ]] && return 1
+  [[ "$resolved" == "$HOME/.claude"/* ]] && return 1
+  chezmoi source-path "$resolved" >/dev/null 2>&1
 }
 
 case "$tool_name" in
   Write | Edit | MultiEdit)
     [[ -z "$file_path" ]] && exit 0
     resolved=$(resolve_path "$file_path")
-    if is_home_not_project "$resolved"; then
+    if is_chezmoi_managed "$resolved"; then
       jq -n --arg reason "$(cat <<MSG
 BLOCKED: Do not edit files in ~/ directly. This is a chezmoi-managed dotfiles repo.
 
@@ -70,7 +74,7 @@ MSG
   Read)
     [[ -z "$file_path" ]] && exit 0
     resolved=$(resolve_path "$file_path")
-    if is_home_not_project "$resolved"; then
+    if is_chezmoi_managed "$resolved"; then
       jq -n --arg ctx "$(cat <<MSG
 Note: You are reading a chezmoi-managed destination file. This is deployed from
 the source tree — do not edit it directly. To find the source file, run:

--- a/test/enforce-source-dir-hook.bats
+++ b/test/enforce-source-dir-hook.bats
@@ -12,6 +12,29 @@ setup() {
   mkdir -p "$CLAUDE_PROJECT_DIR/home"
   touch "$HOME/.zshrc"
   touch "$HOME/.config/ghostty/config"
+
+  # Stub `chezmoi` so the hook's `chezmoi source-path` check is deterministic
+  # regardless of the runner's actual chezmoi state. The fixture treats the
+  # fixture files under fake $HOME as "managed" and treats anything under
+  # $HOME/src/ as "not managed" (i.e. an unrelated repo that happens to live
+  # inside the user's home directory — the case that motivated the hook fix).
+  STUB_BIN="$TEST_TMPDIR/bin"
+  mkdir -p "$STUB_BIN"
+  cat > "$STUB_BIN/chezmoi" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  source-path)
+    case "$2" in
+      */fakehome/src/*) exit 1 ;;     # unrelated repos under $HOME
+      */fakehome/*) exit 0 ;;         # everything else under fake $HOME = managed
+      *) exit 1 ;;
+    esac
+    ;;
+  *) exit 1 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/chezmoi"
+  export PATH="$STUB_BIN:$PATH"
 }
 
 teardown() {
@@ -57,6 +80,15 @@ run_hook() {
 
 @test "Edit to /tmp file is allowed" {
   run_hook "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"/tmp/scratch.txt\"}}"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# --- Write/Edit: allow unrelated repos under $HOME (the bug this hook fix addresses) ---
+
+@test "Write to unrelated repo under \$HOME is allowed when chezmoi says not managed" {
+  mkdir -p "$HOME/src/github.com/some-org/some-repo"
+  run_hook "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$HOME/src/github.com/some-org/some-repo/main.go\"}}"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }


### PR DESCRIPTION
## Summary

- Replace the path-prefix heuristic in `is_home_not_project` with a direct `chezmoi source-path` check (renamed to `is_chezmoi_managed`).
- Fast-path filters still short-circuit so we only shell out to chezmoi for paths that could plausibly be managed.
- Applies to both the Write/Edit/MultiEdit deny branch and the Read warning branch.

## Why

The old check denied Write/Edit to **any** path under `$HOME` outside the project tree. That over-triggered on unrelated repos under `~/src/<org>/<repo>/`, blocking Claude Code agents from doing work in other checkouts whenever a session was rooted in dotfiles. Two subagents hit this today as a hard blocker (ONL-17, ONL-22). The hook's actual intent is to protect chezmoi *destination* files — asking chezmoi directly is precise.

## Verified locally with mock hook inputs

| Path | Before | After |
| --- | --- | --- |
| `~/.config/git/ignore` (managed) | DENY | DENY |
| `~/.config/fish/config.fish` (managed) | DENY | DENY |
| `<project>/home/dot_config/git/ignore` (source) | ALLOW | ALLOW |
| `~/.claude/settings.json` | ALLOW | ALLOW |
| `~/src/github.com/onlooker-community/onlooker/internal/watcher/watcher.go` | DENY | ALLOW |
| `~/src/github.com/onlooker-community/marketplace/tests/sentinel-smoke.test.ts` | DENY | ALLOW |
| `/tmp/something.txt` | ALLOW | ALLOW |

## Test plan

- [x] Probe matrix above against the updated hook
- [x] `shellcheck` on the file (only pre-existing warnings remain — SC2154, SC2001, SC2016 — none introduced by this change)
- [ ] CI: lint + install-matrix + BATS