### PR TITLE
chore(claude): require /commit + American English for agents :nail_care:

### DIFF
--- a/home/dot_claude/CLAUDE.md
+++ b/home/dot_claude/CLAUDE.md
@@ -6,6 +6,16 @@ Precedence: project CLAUDE.md > this file > external docs.
 
 Use mise exclusively (`mise use TOOL@VERSION`). No brew, apt, npm -g, or pipx unless mise lacks the tool—then ask first. No version bumps without explicit instruction.
 
+## Commits
+
+Always route commits through the `/commit` skill — both the main agent and subagents — for every commit, even tiny ones. Do not craft `git commit -m "..."` ad hoc. The skill enforces conventional commits, intentional file selection, mood-based emoji that reflects *this* change (not the type label), and American English.
+
+If you are a subagent and `/commit` is not in your skill list, mirror its contract manually instead of inventing your own: `<type>(<scope>): <subject> :emoji:`, American English, why-focused body. Prefer asking the orchestrating agent to run `/commit` over committing yourself.
+
+## Writing language
+
+Use **American English** in commits, PR / issue descriptions, code comments, identifiers, and docs: `color`, `behavior`, `normalize`, `organize`, `canceled`, `center`, `analyze`, `license`, `catalog`, `gray`, `program`. When integrating with third-party APIs that ship British spellings (e.g. `Element.cloneNode`), keep the upstream spelling — match what the consuming code already uses. The `/commit` skill enforces this for commit messages; this rule covers everything else you write.
+
 ## Skills
 
 | Task | Invocation |

--- a/home/dot_claude/agents/shell-wizard.md
+++ b/home/dot_claude/agents/shell-wizard.md
@@ -59,3 +59,7 @@ main "$@"
 ## Examples
 Request: "Write a script to download and install a tool" → Action: Create script with safe header, download function, install function, validation, and main() orchestration.
 Request: "Fix this existing shell script" → Action: Apply safety header, refactor into functions, format commands properly, run shellcheck validation.
+
+## Commits & writing
+
+If the task ends in a commit, route it through the `/commit` skill rather than running `git commit -m ...` directly — it enforces conventional commits, mood-based emoji that reflects the change (not the type), and American English. If `/commit` is unavailable, mirror the same contract manually or hand the commit back to the orchestrator. Use American English in all script comments, docstrings, log messages, and any PR/issue copy you produce (`color`, `behavior`, `normalize`, `canceled`, `center`, `analyze`).

--- a/home/dot_claude/agents/tdd-guardian.md
+++ b/home/dot_claude/agents/tdd-guardian.md
@@ -155,3 +155,7 @@ Capture this in your first response so subsequent cycles are fast.
 - When refusing to write production code without a test, be brief and specific about the missing step — never moralize.
 
 You are not a code generator. You are a discipline. Hold the line.
+
+## Commits & writing
+
+When a REFACTOR or KILL MUTANTS step ends in a commit, route it through the `/commit` skill rather than running `git commit -m ...` directly — it enforces conventional commits, mood-based emoji that reflects *this* change (not the type), and American English. If `/commit` is unavailable in your session, mirror the same contract manually (`<type>(<scope>): <subject> :emoji:`, why-focused body) or hand the commit back to the orchestrator. Use American English in test names, assertion messages, and audit reports (`color`, `behavior`, `normalize`, `canceled`, `center`, `analyze`).

--- a/home/dot_claude/skills/commit/SKILL.md
+++ b/home/dot_claude/skills/commit/SKILL.md
@@ -70,7 +70,15 @@ Exclude:
 - **Arguments provide message** → use it (adjust format if needed)
 - **No message** → draft based on staged changes, explain reasoning
 
-**Mood emoji:** End every subject line with a GitHub emoji that reflects the vibe of the conversation or task. Intuit mood from context — the ticket being worked on, the user's tone, frustration level, excitement, etc.
+**Mood emoji:** End every subject line with a GitHub emoji that reflects the *content and vibe of this specific change*. Intuit mood from context — the ticket being worked on, the user's tone, frustration level, excitement, etc.
+
+**Anti-pattern — do NOT pick the emoji from the conventional-commit type.** `feat` is not always `:sparkles:`, `fix` is not always `:bug:`, `chore` is not always `:broom:`. The emoji describes *this change*, not the type label:
+
+- `feat` could be `:relieved:` (finally shipping a long-running effort), `:coffin:` (the new feature replaces a dead subsystem), or `:thinking:` (an exploratory MVP).
+- `fix` could be `:tada:` (closes a flaky test that's bitten us for months), `:rage:` (had to dig into vendor code to find it), or `:relieved:` (root cause finally pinned down).
+- `chore(deps)` could be `:fire:` (chained bumps shipping fast) or `:nail_care:` (final lockfile polish).
+
+If the emoji is mechanically derivable from the type, you've picked the wrong emoji — re-read the diff and the conversation.
 
 Palette (use these or any GitHub emoji that fits):
 
@@ -89,7 +97,26 @@ Palette (use these or any GitHub emoji that fits):
 | :rocket: | `:rocket:` | shipping, deploying, launching |
 | :nail_care: | `:nail_care:` | polish, aesthetics, making it pretty |
 
-### 4. Execute Commit
+### 4. Verify Language (American English)
+
+Before running `git commit`, scan the subject + body and convert any British spellings to American English. This applies to commit messages and any PR/issue copy drafted alongside them — not to code identifiers or third-party names that legitimately ship British spellings (e.g. `Element.cloneNode`).
+
+| British | American |
+|---------|----------|
+| colour, favourite, behaviour, honour, flavour | color, favorite, behavior, honor, flavor |
+| normalise, organise, customise, optimise, recognise, prioritise, summarise | normalize, organize, customize, optimize, recognize, prioritize, summarize |
+| normalisation, organisation, customisation, optimisation | normalization, organization, customization, optimization |
+| cancelled, labelled, signalled, modelled, travelled | canceled, labeled, signaled, modeled, traveled |
+| centre, theatre, fibre, metre, litre | center, theater, fiber, meter, liter |
+| analyse, paralyse, catalyse | analyze, paralyze, catalyze |
+| licence (noun), defence, offence, pretence | license, defense, offense, pretense |
+| catalogue, dialogue, analogue | catalog, dialog, analog |
+| grey, programme (computing), whilst, amongst | gray, program, while, among |
+| judgement, acknowledgement, ageing | judgment, acknowledgment, aging |
+
+If unsure, prefer the spelling the codebase already uses; fall back to American English when there is no precedent.
+
+### 5. Execute Commit
 
 ```bash
 git commit -m "$(cat <<'EOF'
@@ -100,7 +127,7 @@ EOF
 )"
 ```
 
-### 5. Verify
+### 6. Verify
 
 Run `git status` to confirm clean state or show remaining changes.
 


### PR DESCRIPTION
## Summary

Subagents have been crafting commit messages ad hoc — sometimes with British spellings (`colour`, `behaviour`, `normalisation`) and without the mood emoji `/commit` expects. This tightens the rule in three durable places so commits look consistent no matter which agent originates them, and clarifies that emoji should reflect the *change content*, not be mechanically derived from the conventional-commit type.

## Scope

- [ ] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

Files touched:

- `home/dot_claude/skills/commit/SKILL.md` — British→American conversion table run before `git commit`, plus an anti-pattern note that `feat` ≠ `:sparkles:`, `fix` ≠ `:bug:`, `chore` ≠ `:broom:`.
- `home/dot_claude/CLAUDE.md` — global rule that every agent (main + subagents) routes commits through `/commit`, plus an American English rule for all writing.
- `home/dot_claude/agents/shell-wizard.md`, `home/dot_claude/agents/tdd-guardian.md` — per-agent anchor so the contract is visible even when the subagent's isolated context misses the global `CLAUDE.md`. `reviewer` and `pr-feedback-reviewer` are read-only and don't commit, so they're left alone.

## Verification

- [ ] `hk check` clean — only the `gitleaks` step ran (other steps reported 0 modified files post-commit). `gitleaks` is not installed locally (`sh: gitleaks: command not found`); CI will run the real check.
- [x] `./bin/test` green — 52/52 passing.
- [x] `chezmoi diff` previewed — only the four edited files update under `~/.claude/`.
- [ ] Template renders verified — N/A, no `.tmpl` files touched.
- [x] N/A — docs/config-only change (all four files are markdown content destined for `~/.claude/`).

## Linked work

none