### PR TITLE
docs(agents): require PR template for every gh pr create :memo:

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Coding agents (and humans) use this file as the **entry map** for this repositor
 2. **Progressive disclosure** — This file inventories components; deep procedures live in `docs/` and skills.
 3. **Packages** — New tools: **`/install <package>`** (pinned manifests, repo conventions). **Package Manager subagent** for sensitive or bulk changes (list below)—not ad-hoc version bumps in those files.
 4. **Hooks** — In this repo, `.claude/hooks/` may enforce source-only edits; still follow the rules even when hooks are off.
+5. **Pull requests** — Always populate `.github/PULL_REQUEST_TEMPLATE.md` when opening a PR (whether via the `/pr` skill or a direct `gh pr create`). Fill it honestly: only tick Scope items the change actually touches, only tick Verification items you actually ran, and call out tools you couldn't run (e.g. "`gitleaks` not installed locally — CI will check") instead of skipping silently. Same for issue templates under `.github/ISSUE_TEMPLATE/`.
 
 ---
 


### PR DESCRIPTION
## Summary

The PR template shipped in 5a81cdc, but PR #39 was opened via direct `gh pr create` with a free-form body and only re-templated after the user pointed it out. This adds operating rule #5 to `AGENTS.md` so the next PR uses `.github/PULL_REQUEST_TEMPLATE.md` the first time — whether it's opened via the `/pr` skill or a raw `gh pr create` — and surfaces the same expectation for issue templates under `.github/ISSUE_TEMPLATE/`.

## Scope

- [ ] Chezmoi source (`home/`)
- [x] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

Single-line edit to `AGENTS.md` (and via the symlink, `CLAUDE.md`).

## Verification

- [ ] `hk check` clean — pipeline aborts on the `gitleaks` step (`sh: gitleaks: command not found` locally); the trailing-whitespace / newlines / markdown-lint steps abort as a consequence. CI will run the full check.
- [x] `./bin/test` green — 52/52 passing.
- [x] `chezmoi diff` previewed — no new managed-path changes from this PR (`AGENTS.md` is repo-root, not under `home/`).
- [ ] Template renders verified — N/A, no `.tmpl` files touched.
- [x] N/A — docs/config-only change (single line added to `AGENTS.md`).

## Linked work

References #29 (PR/issue templates were introduced there). No issues to close.