### PR TITLE
chore(mise): pin gitleaks v8.30.1 so hk check runs locally :relieved:

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -23,6 +23,38 @@ url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
 [tools."aqua:bats-core/bats-core"."platforms.macos-x64"]
 url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
 
+[[tools."aqua:gitleaks/gitleaks"]]
+version = "v8.30.1"
+backend = "aqua:gitleaks/gitleaks"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.linux-arm64"]
+checksum = "sha256:e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_arm64.tar.gz"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.linux-arm64-musl"]
+checksum = "sha256:e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_arm64.tar.gz"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.linux-x64"]
+checksum = "sha256:551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.linux-x64-musl"]
+checksum = "sha256:551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.macos-arm64"]
+checksum = "sha256:b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_darwin_arm64.tar.gz"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.macos-x64"]
+checksum = "sha256:dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_darwin_x64.tar.gz"
+
+[tools."aqua:gitleaks/gitleaks"."platforms.windows-x64"]
+checksum = "sha256:d29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e"
+url = "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_windows_x64.zip"
+
 [[tools."aqua:koalaman/shellcheck"]]
 version = "v0.11.0"
 backend = "aqua:koalaman/shellcheck"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 
 [tools]
 "aqua:bats-core/bats-core" = "v1.13.0"
+"aqua:gitleaks/gitleaks" = "v8.30.1"
 "aqua:koalaman/shellcheck" = "v0.11.0"
 "aqua:mikefarah/yq" = "v4.53.2"
 "aqua:suzuki-shunsuke/ghalint" = "latest"

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,7 @@
   mise: {
     managerFilePatterns: [
       '/^home/dot_config/mise/config\\.toml$/',
+      '/^mise\\.toml$/',
     ],
   },
   'github-actions': {


### PR DESCRIPTION
## Summary

Adds `gitleaks` to the repo's dev-tooling `mise.toml` via `aqua:gitleaks/gitleaks` (matches the existing security-adjacent linters: `shellcheck`, `ghalint`), pinned to v8.30.1 — current stable as of 2026-05-16, with per-platform checksums captured in `mise.lock`. Also extends `renovate.json5`'s `mise.managerFilePatterns` to cover the repo-root `mise.toml` (previously scoped only to `home/dot_config/mise/config.toml`) so Renovate will routinely bump the new pin alongside the other dev-tooling tools. Closes #41.

## Scope

- [ ] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [x] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

Files touched: `mise.toml`, `mise.lock`, `renovate.json5`. Pin choice and Renovate-pattern decision routed through the **Package Manager subagent** per `AGENTS.md` operating rule #3, not picked ad-hoc.

## Verification

- [x] `hk check` clean — full pipeline now runs end-to-end on this branch (`check-merge-conflict`, `check-symlinks`, `check-executables-have-shebangs`, `newlines`, `mixed-line-ending`, `detect-private-key`, `trailing-whitespace`, `gitleaks` ("no leaks found"), `mise`). Previously aborted at `gitleaks` on every contributor box without it pre-installed.
- [x] `./bin/test` green — 52/52 passing.
- [x] `chezmoi diff` previewed — no new managed-path changes from this PR.
- [ ] Template renders verified — N/A, no `.tmpl` files touched.
- [ ] N/A — docs/config-only change (this is a real manifest change, not docs-only).

Additional upstream sanity-check: `GET api.github.com/repos/gitleaks/gitleaks/releases/latest` returns `tag_name: v8.30.1, prerelease: false, published_at: 2026-03-21T02:17:58Z`. `mise install` pulled the darwin-arm64 artifact with checksum verification; `gitleaks version` reports `8.30.1`.

## Linked work

Closes #41. Unblocks the "`hk check` clean" verification box in future PRs — see PRs #39 and #40 where it had to be deferred to CI.