### PR TITLE
fix(ci): pass GITHUB_TOKEN to mise-action and child scripts :relieved:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           persist-credentials: false
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
       - name: Run linting checks
         run: hk check
 
@@ -71,7 +73,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
         run: |
-          GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false ./install
+          GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false GITHUB_TOKEN="$GITHUB_TOKEN" ./install
       - name: Dump install logs on failure
         if: failure()
         run: |
@@ -84,7 +86,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
         run: |
-          ./bin/setup
+          GITHUB_TOKEN="$GITHUB_TOKEN" ./bin/setup
       - name: Run test suite
         run: |
           ./bin/test


### PR DESCRIPTION
## Summary

Without `GITHUB_TOKEN`, mise hits unauthenticated GitHub API rate limits when resolving tool releases, causing flaky CI. This plumbs the token into `mise-action` via `env:` and forwards it explicitly to `./install` and `./bin/setup` so child processes can authenticate too.

## Scope

- [ ] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [x] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)

## Verification

- [ ] `hk check` clean
- [ ] `./bin/test` green
- [ ] `chezmoi diff` previewed and only intended paths changed
- [x] N/A — CI config-only change

## Linked work

none