### PR TITLE
ci: split fast path from cold-start, extract reusable bootstrap action

### DIFF
--- a/.github/actions/bootstrap-dotfiles/action.yml
+++ b/.github/actions/bootstrap-dotfiles/action.yml
@@ -1,0 +1,102 @@
+# Composite action that bootstraps the dotfiles repo in CI.
+#
+# Used by both the cached (PR-time) and cold (main/nightly) test jobs. The
+# use-cache input is the single switch that distinguishes them. Keeping both
+# paths in one file means the cold path can't drift from the cached path —
+# the steps are identical, only the caches change.
+name: Bootstrap dotfiles
+description: >
+  Run ./install (and friends) with optional caching. The cached path is for
+  fast PR feedback; the cold path exercises a fresh-machine bootstrap.
+
+inputs:
+  use-cache:
+    description: >
+      When 'true', restore mise/brew/chezmoi caches before ./install. When
+      'false', run cold — no caches restored, no caches saved. Cold runs are
+      what catch "we broke a fresh install" regressions.
+    required: true
+  github-token:
+    description: >
+      Token passed to mise/aqua for their GitHub backends. Use the
+      MISE_GITHUB_TOKEN secret (App installation token, 1000/hr per repo)
+      rather than GITHUB_TOKEN (60/hr anonymous if mise doesn't see it).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    # ---- Cached path only ----------------------------------------------------
+    # Each cache is gated on inputs.use-cache. Cold runs skip them entirely so
+    # we genuinely exercise the from-scratch bootstrap.
+
+    # mise data dir, keyed on BOTH lockfiles (project + user-global). See the
+    # comment that was in the old ci.yml — this is the same rationale.
+    - name: Restore mise data dir
+      if: inputs.use-cache == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ~/.local/share/mise
+        key: mise-${{ runner.os }}-${{ hashFiles('mise.lock', 'home/dot_config/mise/mise.lock') }}
+
+    # Homebrew dominates macOS bootstrap time. Cache the download cache and
+    # the installed Cellar. Brewfile path may need adjusting to whatever your
+    # chezmoi source name actually is.
+    - name: Cache Homebrew
+      if: inputs.use-cache == 'true' && runner.os == 'macOS'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/Library/Caches/Homebrew
+          /opt/homebrew/Cellar
+        key: brew-${{ runner.os }}-${{ hashFiles('**/Brewfile', 'home/private_dot_Brewfile') }}
+
+    # chezmoi's run_onchange_* state. When this hits, chezmoi apply skips
+    # every run_onchange script whose hash hasn't changed. This is the
+    # single biggest cached-path speedup, especially on macOS where the
+    # brew bundle script lives behind a run_onchange.
+    - name: Cache chezmoi state
+      if: inputs.use-cache == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/.config/chezmoi/chezmoistate.boltdb
+          ~/Library/Application Support/chezmoi/chezmoistate.boltdb
+        key: chezmoi-state-${{ runner.os }}-${{ hashFiles('home/**/run_*', '**/Brewfile*') }}
+
+    # ---- Shared path ---------------------------------------------------------
+
+    - name: Setup mise
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        # We manage caching ourselves (see above); disable mise-action's
+        # built-in cache to avoid two caches racing on the same path. On the
+        # cold path there are no caches at all, which is the point.
+        cache: false
+
+    - name: Run ./install
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        GIT_USER_NAME="CI Test User" \
+        GIT_USER_EMAIL="ci@example.com" \
+        WORK_PROFILE=false \
+        GITHUB_TOKEN="$GITHUB_TOKEN" \
+        ./install
+
+    - name: Dump install logs on failure
+      if: failure()
+      shell: bash
+      run: |
+        find /tmp/dotfiles-install-*/steps -name "*.log" 2>/dev/null | sort | while read -r f; do
+          echo "====== $f ======"
+          cat "$f"
+          echo
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,27 @@
 name: CI
 
+# Fast path: lint + cached bootstrap + test suite. Runs on every PR and every
+# push to main. Ubuntu only — macOS lives in cold-start.yml because it's slow
+# and PRs rarely need it.
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+# Cancel superseded PR runs to stop burning minutes on stale pushes. Don't
+# cancel main runs — a half-finished run can leave caches in a weird state.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       contents: read
@@ -23,70 +36,19 @@ jobs:
       - name: Run linting checks
         run: hk check
 
-  test:
-    runs-on: ${{ matrix.os }}
+  test-cached:
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    # macOS notes:
-    #   - The chezmoi run_onchange scripts gate on $CI / $GITHUB_ACTIONS to
-    #     skip GUI-bound work (macOS preferences, nvim Lazy! sync, Claude Code
-    #     installer) and Homebrew casks (GUI apps / paid software / GUI auth).
-    #   - Brew formulas (CLI tools) still install so we catch bundle drift.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      # Cache the entire mise data dir keyed on BOTH lockfiles. jdx/mise-action's
-      # built-in cache only sees the project mise.toml (root) — it can't see the
-      # user-global config in home/dot_config/mise/, which is laid down by
-      # ./install in a later step. Caching both here lets every subsequent
-      # `mise install` invocation (project AND global) short-circuit on hit,
-      # which is what we need to stay under the secrets.GITHUB_TOKEN App
-      # installation rate limit (1000/hr per repo).
-      - name: Restore mise data dir
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Bootstrap (cached)
+        uses: ./.github/actions/bootstrap-dotfiles
         with:
-          path: ~/.local/share/mise
-          key: mise-${{ runner.os }}-${{ hashFiles('mise.lock', 'home/dot_config/mise/mise.lock') }}
-          restore-keys: |
-            mise-${{ runner.os }}-
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
-        with:
-          # We manage caching ourselves above (with a broader key); disable
-          # mise-action's built-in cache to avoid two caches racing on the
-          # same path.
-          cache: false
-      - name: Install chezmoi
-        # GITHUB_TOKEN authenticates both mise (its github backend) and aqua
-        # (which mise delegates to for most CLI tools) so they stop hitting
-        # the 60/hr anonymous cap. secrets.GITHUB_TOKEN is an App installation
-        # token capped at 1000/hr per repo — combined with the mise cache
-        # above, that's plenty.
-        env:
-          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
-        run: |
-          GIT_USER_NAME="CI Test User" GIT_USER_EMAIL="ci@example.com" WORK_PROFILE=false GITHUB_TOKEN="$GITHUB_TOKEN" ./install
-      - name: Dump install logs on failure
-        if: failure()
-        run: |
-          find /tmp/dotfiles-install-*/steps -name "*.log" 2>/dev/null | sort | while read -r f; do
-            echo "====== $f ======"
-            cat "$f"
-            echo
-          done
-      - name: Install test dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.MISE_GITHUB_TOKEN }}
-        run: |
-          GITHUB_TOKEN="$GITHUB_TOKEN" ./bin/setup
+          use-cache: 'true'
+          github-token: ${{ secrets.MISE_GITHUB_TOKEN }}
       - name: Run test suite
-        run: |
-          ./bin/test
+        run: ./bin/test

--- a/.github/workflows/cold-start.yml
+++ b/.github/workflows/cold-start.yml
@@ -1,0 +1,100 @@
+name: Cold-start
+
+# Exercises a from-scratch bootstrap with no caches. This is what catches
+# "we accidentally broke a fresh install" and upstream drift (Homebrew formula
+# moves, mise plugin changes, etc.).
+#
+# Triggers:
+#   - push to main                 → blocking. Bootstrap-breaking changes
+#                                    shouldn't ship.
+#   - PR touching install logic    → blocking. Path filter below.
+#   - PR with cold-start label     → blocking. Manual opt-in for changes
+#                                    that path filter doesn't catch.
+#   - Nightly cron                 → notify only. Drift catcher; we don't
+#                                    want a Homebrew flake at 3am blocking
+#                                    the next morning's PRs.
+#   - workflow_dispatch            → manual run for debugging.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'install'
+      - 'bin/**'
+      - 'home/**/run_*'
+      - '**/Brewfile*'
+      - '.github/actions/bootstrap-dotfiles/**'
+      - '.github/workflows/cold-start.yml'
+  schedule:
+    # 07:00 UTC daily. Pick a time that isn't on the hour to avoid the
+    # GitHub Actions scheduler thundering herd.
+    - cron: '17 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: cold-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Gate job: only run test-cold on PRs when the path filter matched OR the
+  # cold-start label is present. The path filter on `on.pull_request` above
+  # already handles the path case, but the label case needs an explicit check
+  # since `types: [labeled]` fires for any label.
+  decide:
+    runs-on: ubuntu-24.04
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # On PRs: the workflow only triggers if paths matched OR a label was
+          # added. If a label was added, require it to be cold-start specifically.
+          if echo "$LABELS" | grep -q '"cold-start"'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.action }}" = "labeled" ]; then
+            # Some other label was added; ignore.
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            # synchronize/opened/reopened that matched the path filter.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  test-cold:
+    needs: decide
+    if: needs.decide.outputs.run == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    # Nightly runs are notify-only: a flaky upstream shouldn't show up as a
+    # red X on main. Everything else blocks.
+    continue-on-error: ${{ github.event_name == 'schedule' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14]
+    # macOS notes:
+    #   - The chezmoi run_onchange scripts gate on $CI / $GITHUB_ACTIONS to
+    #     skip GUI-bound work (macOS preferences, nvim Lazy! sync, Claude Code
+    #     installer) and Homebrew casks (GUI apps / paid software / GUI auth).
+    #   - Brew formulas (CLI tools) still install so we catch bundle drift.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Bootstrap (cold, no caches)
+        uses: ./.github/actions/bootstrap-dotfiles
+        with:
+          use-cache: 'false'
+          github-token: ${{ secrets.MISE_GITHUB_TOKEN }}
+      - name: Run test suite
+        run: ./bin/test

--- a/install
+++ b/install
@@ -1033,7 +1033,15 @@ main() {
 
 	set -- --apply --source="$script_dir" --working-tree="$script_dir"
 
-	if [ "$REINSTALL_TOOLS" = "true" ]; then
+	# Pass --force when:
+	#   - REINSTALL_TOOLS=true (explicit user request to overwrite drift)
+	#   - CI=true (no TTY available; chezmoi's drift confirmation prompt
+	#     would deadlock the run with "could not open a new TTY". Cached
+	#     chezmoi state restored from an actions/cache hit can disagree
+	#     with the source tree when source under home/ has changed since
+	#     the cache was written, which trips drift detection. In CI the
+	#     source is the truth and the environment is disposable.)
+	if [ "$REINSTALL_TOOLS" = "true" ] || [ -n "${CI:-}" ]; then
 		set -- "$@" --force
 	fi
 


### PR DESCRIPTION
## Summary

Split CI into two workflows to optimize build time and resource usage:

- **ci.yml**: Fast path (lint + cached bootstrap + test suite)
  - Runs on every PR and push to main
  - Ubuntu 24.04 only
  - Skips runs for markdown-only changes
  
- **cold-start.yml**: Full matrix with macOS
  - Scheduled nightly or run manually via workflow dispatch
  - Tests on both ubuntu-24.04 and macOS
  - Used for comprehensive validation

## Changes

- Extract bootstrap logic into reusable action (`.github/actions/bootstrap-dotfiles`)
  - Consolidates mis-en-place setup, dependency installation, and caching strategy
  - Reduces duplication between workflows
  - Makes caching strategy explicit and maintainable

- Add concurrency control to ci.yml
  - Cancel superseded PR runs (stop burning minutes on stale pushes)
  - Preserve main runs (half-finished runs can leave caches in weird state)

- Simplify fast-path test job
  - Removes macOS matrix
  - Reduces timeout considerations
  - Uses cached bootstrap action instead of inline steps