### PR TITLE
feat(git): render emoji shortcodes in `git lg`/`lga` output :nail_care:

### DIFF
--- a/home/.chezmoidata/packages.yaml
+++ b/home/.chezmoidata/packages.yaml
@@ -14,6 +14,7 @@ packages:
       - awscli
       - coreutils
       - curl
+      - emojify
       - mise
       - pkl-lsp
       - tree

--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -46,26 +46,26 @@
 	br = branch
 	ci = commit
 	st = status
-	
-	# Better logging
-	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
-	lga = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all
-	
+
+	# Better logging — pipes through `emojify` so commit shortcodes (`:bug:`, `:sparkles:`) render as glyphs.
+	lg = "!f() { git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit \"$@\" | emojify | less -FRX; }; f"
+	lga = "!f() { git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all \"$@\" | emojify | less -FRX; }; f"
+
 	# Show files in a commit
 	show-files = show --pretty="" --name-only
-	
+
 	# Undo last commit
 	undo = reset HEAD~1 --mixed
-	
+
 	# Clean up merged branches
 	cleanup = "!git branch --merged | grep -v '\\*\\|main\\|master\\|develop' | xargs -n 1 git branch -d"
-	
+
 	# Quick commit and push
 	cap = "!git add . && git commit -m"
-	
+
 	# Interactive rebase
 	ri = rebase -i
-	
+
 	# Show current branch
 	current = branch --show-current
 


### PR DESCRIPTION
## Summary

`git lg` and `lga` piped their output through the shortcode-aware emoji renderer `emojify`, so conventional-commit subject lines like `fix(auth): patch null deref :bug:` display actual glyphs instead of raw `:bug:` text. Bare `git log` is left alone. `emojify` is added to the darwin brew manifest so `chezmoi apply` installs it automatically.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)

## Verification

- [x] `hk check` clean
- [ ] `./bin/test` green (set `CI=1 GITHUB_ACTIONS=1` if your change touches a chezmoi template that branches on CI)
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Template renders verified with `chezmoi execute-template --file home/dot_config/git/config.tmpl`

## Linked work

none