### PR TITLE
fix(pr): pin `claude-extract` for session gist export :relieved:

### DIFF
--- a/home/dot_claude/skills/pr/executable_claude-extract-session
+++ b/home/dot_claude/skills/pr/executable_claude-extract-session
@@ -81,7 +81,11 @@ find_session_number() {
     #   N. <folder>
     #      Session: <truncated-id>...
     local list_output
-    list_output=$(claude-extract --list 2>&1) || die "failed to list sessions"
+    if ! list_output=$(claude-extract --list 2>&1); then
+        log "claude-extract --list failed; output was:"
+        printf '%s\n' "${list_output}" >&2
+        die "failed to list sessions"
+    fi
 
     local current_number=""
     local found_number=""

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -1,4 +1,4 @@
-{{- /* 
+{{- /*
 # -*-mode:toml-*- vim:ft=toml.gotexttmpl
 */ -}}
 
@@ -190,9 +190,10 @@ fnox    = "latest"
 "npm:@google/gemini-cli"  = { version = "latest", minimum_release_age = "2d" }
 
 ### AI utility
-"aqua:rtk-ai/rtk"            = "latest" # High-performance CLI proxy that reduces LLM token consumption by 60-90%
-"github:dyoshikawa/rulesync" = "latest" # A Utility CLI for AI Coding Agents
-"github:googleworkspace/cli" = "latest" # Google Workspace CLI
+"aqua:rtk-ai/rtk"                    = "latest" # High-performance CLI proxy that reduces LLM token consumption by 60-90%
+"github:dyoshikawa/rulesync"         = "latest" # A Utility CLI for AI Coding Agents
+"github:googleworkspace/cli"         = "latest" # Google Workspace CLI
+"pipx:claude-conversation-extractor" = "latest" # `claude-extract` CLI — used by the `/pr` skill to gist session logs
 
 ### MCP servers
 "pipx:mcp-server-time"  = "latest" # MCP server for time and timezone conversion capabilities


### PR DESCRIPTION
## Summary

The `/pr` skill silently dropped conversation Gists because `pipx:claude-conversation-extractor` was installed locally but never pinned in `home/dot_config/mise/config.toml.tmpl`. With no `[tools]` entry the mise shim refused to dispatch, and `claude-extract-session` masked the real error behind a generic `failed to list sessions`. Adds the pin and surfaces mise's stderr so future drift is self-diagnosing.

Closes #47

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)

## Verification

- [x] `hk check` clean
- [ ] `./bin/test` green (set `CI=1 GITHUB_ACTIONS=1` if your change touches a chezmoi template that branches on CI)
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Template renders verified with `chezmoi execute-template --file home/dot_config/mise/config.toml.tmpl`
- [x] Improved error path verified: running `claude-extract-session` now surfaces `mise ERROR No version is set for shim: claude-extract` before the generic failure message

## Linked work

Closes #47

---

> **Note:** Gist export still fails until `chezmoi apply` is run after merge — this PR is fixing its own prerequisite.