### PR TITLE
fix(pr): expand `$tmpdir` at trap registration :broom:

### DIFF
--- a/home/dot_claude/skills/pr/executable_claude-extract-session
+++ b/home/dot_claude/skills/pr/executable_claude-extract-session
@@ -121,8 +121,11 @@ extract_session() {
     # Create temporary directory for extraction
     tmpdir=$(mktemp -d) || die "failed to create temporary directory"
 
-    # Ensure cleanup on exit
-    trap 'rm -rf "${tmpdir}"' EXIT
+    # Ensure cleanup on exit. Expand $tmpdir at trap registration (double quotes)
+    # rather than at trap firing — the local var goes out of scope when the
+    # function returns, but EXIT fires later, triggering set -u.
+    # shellcheck disable=SC2064
+    trap "rm -rf -- '${tmpdir}'" EXIT
 
     log "extracting session #${session_number}..."
 


### PR DESCRIPTION
## Summary

`extract_session` registered its EXIT cleanup trap with single quotes — `trap 'rm -rf "${tmpdir}"' EXIT` — so `${tmpdir}` wasn't expanded until the trap fired. By that point `tmpdir` had gone out of scope (`local` to the function, function already returned), and `set -o nounset` printed `line 188: tmpdir: unbound variable` after every successful gist export. Switches to double quotes so the path is captured at registration time while the local is still alive.

## Scope

- [ ] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)

## Verification

- [x] `hk check` clean
- [ ] `./bin/test` green (set `CI=1 GITHUB_ACTIONS=1` if your change touches a chezmoi template that branches on CI)
- [ ] `chezmoi diff` previewed and only intended paths changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [x] Script run directly (`bash home/dot_claude/skills/pr/executable_claude-extract-session <session-id>`) — exits 0, no unbound-var output

## Linked work

Spotted during the PR that opened #49 (ADR 0004). No issue filed — one-liner with a clear root cause.

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/3455b365801c943ce2c5a157f7d26664)