### PR TITLE
feat(karabiner): track NJ80 keyboard remaps under chezmoi

### DIFF
--- a/home/dot_config/karabiner/karabiner.json
+++ b/home/dot_config/karabiner/karabiner.json
@@ -1,0 +1,48 @@
+{
+  "global": {
+    "show_in_menu_bar": false
+  },
+  "profiles": [
+    {
+      "complex_modifications": {},
+      "devices": [
+        {
+          "identifiers": {
+            "is_keyboard": true,
+            "is_pointing_device": true,
+            "product_id": 16387,
+            "vendor_id": 12625
+          },
+          "ignore": false
+        }
+      ],
+      "name": "NJ80 Keyboard",
+      "selected": true,
+      "simple_modifications": [
+        {
+          "from": {
+            "key_code": "caps_lock"
+          },
+          "to": [
+            {
+              "key_code": "left_control"
+            }
+          ]
+        },
+        {
+          "from": {
+            "key_code": "right_command"
+          },
+          "to": [
+            {
+              "key_code": "f18"
+            }
+          ]
+        }
+      ],
+      "virtual_hid_keyboard": {
+        "keyboard_type_v2": "ansi"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Brings karabiner-elements config under chezmoi so the NJ80 keyboard remaps survive a fresh machine. Two simple modifications: \`caps_lock\` → \`left_control\` and \`right_command\` → \`f18\` (the latter is the trigger key for the hyper-key chain used elsewhere in the setup). Menu-bar icon hidden globally.

## Scope

- [x] Chezmoi source (\`home/\`)
- [ ] Docs (\`docs/\`, \`README.md\`, \`AGENTS.md\`)
- [ ] CI / GitHub Actions (\`.github/workflows/\`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (\`home/dot_claude/\` — skills, agents, hooks)
- [ ] Repo tooling (\`bin/\`, \`test/\`, \`hk.pkl\`, \`mise.toml\`)
- [ ] Other:

## Verification

- [ ] \`hk check\` clean — not run locally; CI will check
- [ ] \`./bin/test\` green — not run locally; CI will check
- [ ] \`chezmoi diff\` previewed and only intended paths changed — not run; expected new paths under \`~/.config/karabiner/\`
- [ ] Template renders verified — N/A (no \`.tmpl\` changes)
- [x] N/A — net-new config files only

## Linked work

none