### PR TITLE
fix(git): run emojify under brew bash for git lg/lga

### DIFF
--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -48,8 +48,10 @@
 	st = status
 
 	# Better logging — pipes through `emojify` so commit shortcodes (`:bug:`, `:sparkles:`) render as glyphs.
-	lg = "!f() { git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit \"$@\" | emojify | less -FRX; }; f"
-	lga = "!f() { git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all \"$@\" | emojify | less -FRX; }; f"
+	# `emojify`'s shebang resolves bash via PATH and macOS picks /bin/bash 3.2.57, which modern emojify rejects —
+	# so invoke it under brew's bash explicitly, falling back to PATH bash on systems without brew.
+	lg = "!f() { b=\"$(brew --prefix bash 2>/dev/null)/bin/bash\"; [ -x \"$b\" ] || b=bash; git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit \"$@\" | \"$b\" \"$(command -v emojify)\" | less -FRX; }; f"
+	lga = "!f() { b=\"$(brew --prefix bash 2>/dev/null)/bin/bash\"; [ -x \"$b\" ] || b=bash; git log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all \"$@\" | \"$b\" \"$(command -v emojify)\" | less -FRX; }; f"
 
 	# Show files in a commit
 	show-files = show --pretty="" --name-only


### PR DESCRIPTION
## Summary

`git lg` and `git lga` started bailing with "Oh my! That's a very old version of bash you're using" because modern `emojify` dropped bash 3.2 support. `#!/usr/bin/env bash` in emojify's shebang does a PATH lookup and macOS's `/bin/bash` (3.2.57) wins, so the script aborts before rendering. Pin the pipeline to homebrew's bash explicitly (with a PATH-bash fallback for non-brew systems) so emoji glyphs render in `git log` output again.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test\`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [ ] `./bin/test` green — not run (no test surface changed)
- [x] `chezmoi diff` previewed and only `~/.config/git/config` changed
- [ ] Template renders verified — N/A (`.tmpl` touched but no template syntax used in the changed lines; rendered output checked via `chezmoi execute-template` and `git lga` smoke-tested locally)
- [ ] N/A — docs/config-only change

Verified locally: `git lga -n 5` now renders `:sparkles:` → ✨, `:broom:` → 🧹, `:nail_care:` → 💅 as expected.

## Linked work

Regression after #46 (which introduced the emojify pipeline). No issue tracked.