### PR TITLE
feat(nvim): file explorer, LSP completion, and keymap hints via mini.nvim

### DIFF
--- a/home/dot_config/nvim/plugin/mini.lua
+++ b/home/dot_config/nvim/plugin/mini.lua
@@ -8,7 +8,9 @@ vim.pack.add({
 
 local function setup(module, opts)
   local ok, mod = pcall(require, module)
-  if ok then mod.setup(opts or {}) end
+  if ok then
+    mod.setup(opts or {})
+  end
   return ok
 end
 
@@ -17,16 +19,32 @@ setup("mini.pairs")
 setup("mini.surround")
 setup("mini.comment")
 setup("mini.ai")
+setup("mini.files")
 setup("mini.statusline", { use_icons = false })
 
 -- Buffer management bindings paired with mini.bufremove so closing a
 -- buffer doesn't kill the window layout.
 local ok_bufremove, bufremove = pcall(require, "mini.bufremove")
 if ok_bufremove then
-  vim.keymap.set("n", "<Space>bd", function() bufremove.delete(0, false) end, { desc = "Buffer: delete" })
-  vim.keymap.set("n", "<Space>bD", function() bufremove.delete(0, true) end, { desc = "Buffer: delete (force)" })
+  vim.keymap.set("n", "<Space>bd", function()
+    bufremove.delete(0, false)
+  end, { desc = "Buffer: delete" })
+  vim.keymap.set("n", "<Space>bD", function()
+    bufremove.delete(0, true)
+  end, { desc = "Buffer: delete (force)" })
 end
 
 vim.keymap.set("n", "<Space>bn", "<cmd>bnext<CR>", { desc = "Buffer: next" })
 vim.keymap.set("n", "<Space>bp", "<cmd>bprevious<CR>", { desc = "Buffer: previous" })
 vim.keymap.set("n", "<Space>bb", "<cmd>buffer #<CR>", { desc = "Buffer: alternate" })
+
+-- mini.files explorer; opens at the current buffer's path so navigation
+-- starts where you already are. Toggles closed if already open.
+local ok_files, files = pcall(require, "mini.files")
+if ok_files then
+  vim.keymap.set("n", "<Space>e", function()
+    if not files.close() then
+      files.open(vim.api.nvim_buf_get_name(0))
+    end
+  end, { desc = "Files: toggle explorer at current buffer" })
+end

--- a/home/dot_config/nvim/plugin/mini.lua
+++ b/home/dot_config/nvim/plugin/mini.lua
@@ -49,3 +49,38 @@ if ok_files then
     end
   end, { desc = "Files: toggle explorer at current buffer" })
 end
+
+-- mini.clue — keymap hint popup after a prefix is pressed. Triggers list
+-- only the prefixes we actually use (custom + the common vim built-ins);
+-- gen_clues fills in descriptions for the built-in ones automatically.
+local ok_clue, clue = pcall(require, "mini.clue")
+if ok_clue then
+  clue.setup({
+    triggers = {
+      { mode = "n", keys = "<Leader>" },
+      { mode = "x", keys = "<Leader>" },
+      { mode = "n", keys = "g" },
+      { mode = "x", keys = "g" },
+      { mode = "n", keys = "[" },
+      { mode = "n", keys = "]" },
+      { mode = "n", keys = "z" },
+      { mode = "x", keys = "z" },
+      { mode = "n", keys = '"' },
+      { mode = "x", keys = '"' },
+      { mode = "i", keys = "<C-r>" },
+      { mode = "c", keys = "<C-r>" },
+      { mode = "n", keys = "<C-w>" },
+    },
+    clues = {
+      clue.gen_clues.builtin_completion(),
+      clue.gen_clues.g(),
+      clue.gen_clues.marks(),
+      clue.gen_clues.registers(),
+      clue.gen_clues.windows(),
+      clue.gen_clues.z(),
+      { mode = "n", keys = "<Leader>b", desc = "+Buffer" },
+      { mode = "n", keys = "<Leader>l", desc = "+LSP" },
+    },
+    window = { delay = 200 },
+  })
+end

--- a/home/dot_config/nvim/plugin/mini.lua
+++ b/home/dot_config/nvim/plugin/mini.lua
@@ -20,6 +20,7 @@ setup("mini.surround")
 setup("mini.comment")
 setup("mini.ai")
 setup("mini.files")
+setup("mini.completion")
 setup("mini.statusline", { use_icons = false })
 
 -- Buffer management bindings paired with mini.bufremove so closing a


### PR DESCRIPTION
## Summary

Three small additions to the native \`plugin/\` nvim config introduced in #51, all pulled from the existing \`mini.nvim\` meta-repo so no new packs are added:

- **mini.files** — \`<Space>e\` toggles a file explorer rooted at the current buffer's path. Second press dismisses.
- **mini.completion** — LSP-aware completion that hooks into the native \`vim.lsp.config\` setup automatically; falls back to two-step \`complete()\` in buffers without an LSP. Signature help on insert comes along for free, and \`completeopt\` was already sane.
- **mini.clue** — pops a hint window after a prefix lingers (\`<Leader>\`, \`g\`, \`[\`, \`]\`, \`z\`, \`<C-w>\`, registers). Built-in vim prefixes get descriptions via \`gen_clues\`; \`<Leader>b\` and \`<Leader>l\` get named groups (\`+Buffer\`, \`+LSP\`).

All three modules are loaded behind \`pcall\` to match the existing pattern in \`plugin/mini.lua\`.

## Scope

- [x] Chezmoi source (\`home/\`)
- [ ] Docs (\`docs/\`, \`README.md\`, \`AGENTS.md\`)
- [ ] CI / GitHub Actions (\`.github/workflows/\`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (\`home/dot_claude/\` — skills, agents, hooks)
- [ ] Repo tooling (\`bin/\`, \`test/\`, \`hk.pkl\`, \`mise.toml\`)
- [ ] Other:

## Verification

- [x] \`hk check\` clean
- [ ] \`./bin/test\` green — not run (no shell-test surface changed)
- [x] \`chezmoi diff\` previewed and only \`~/.config/nvim/plugin/mini.lua\` changed
- [ ] Template renders verified — N/A (no \`.tmpl\` files touched)
- [ ] N/A — docs/config-only change

Headless verification:
- \`require("mini.files")\`, \`require("mini.completion")\`, \`require("mini.clue")\` all resolve.
- \`<Space>e\` keymap registers; \`MiniClue.gen_clues.{builtin_completion,g,marks,registers,windows,z}\` all functions.
- Interactive smoke-test: file explorer opens at current buffer, closes on second press; hint popup appears after the configured \`<Space>\` delay.

## Linked work

Builds on #51 (native plugin/ config, replacing LazyVim). No issue tracked.