### PR TITLE
docs(adr): use first-person voice in 0007 :nail_care:

### DIFF
--- a/docs/adrs/0007-window-management-strategy.md
+++ b/docs/adrs/0007-window-management-strategy.md
@@ -18,7 +18,7 @@ versus [`home/.chezmoidata/packages.yaml`](../../home/.chezmoidata/packages.yaml
 [AeroSpace](https://nikitabobko.github.io/AeroSpace/) (a tiling window manager built on virtual
 workspaces rather than macOS Spaces) is the desired direction. But adopting a tiling WM the obvious
 way — install it, let it tile everything — is exactly the failure mode that has stalled this before:
-windows fly to positions you didn't choose, the manual arrangements you rely on disappear, and there's
+windows fly to positions I didn't choose, the manual arrangements I rely on disappear, and there's
 no graceful way to "arrange this one thing by hand" mid-flow. Going all-in on tiling in a single step
 trades one working setup for a broken-feeling one and a steep relearning cliff.
 


### PR DESCRIPTION
## Summary

Restores the first-person wording in ADR 0007's problem statement ("windows fly to positions I didn't choose…"). The edit was made while reviewing #72 but lost in a merge race, so it lands here as a one-line follow-up.

## Scope

- [ ] Chezmoi source (`home/`)
- [x] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other: <!-- describe -->

## Verification

- [ ] `hk check` clean
- [ ] `./bin/test` green
- [ ] `chezmoi diff` previewed and only intended paths changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>`
- [x] N/A — docs-only change

## Linked work

Follow-up to #72 (ADR 0007).

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/77a29d4177950fb6db415d60e1149da0)