### PR TITLE
fix(aerospace): pin workspaces to monitors on multi-monitor :relieved:

### DIFF
--- a/home/dot_config/aerospace/aerospace.toml
+++ b/home/dot_config/aerospace/aerospace.toml
@@ -45,6 +45,29 @@ outer.bottom = 8
 outer.top = 8
 outer.right = 8
 
+# ── Workspaces → monitors ─────────────────────────────────────────────────────
+# Multi-monitor calm (Phase 1 refinement). Without this, an unassigned workspace
+# defaults to the *main* monitor, so all of 1–9 piled onto the ultrawide and
+# `alt+1..9` yanked windows around that one screen while the other two displays
+# held unreachable workspaces. Pinning each workspace to a monitor gives every
+# screen its own stable lane: `alt+N` jumps to that workspace's monitor and only
+# that monitor changes — windows never cross screens on a switch.
+#
+# Monitors are matched by name (regex), so this survives macOS renumbering them.
+# If a monitor is disconnected (e.g. undocked), AeroSpace falls back to the main
+# display for its workspaces — so an undocked laptop still reaches 1–9.
+#   S34J55x  = ultrawide (main) · Built-in = laptop · DELL U2417H = portrait
+[workspace-to-monitor-force-assignment]
+1 = 'S34J55x'
+2 = 'S34J55x'
+3 = 'S34J55x'
+4 = 'S34J55x'
+5 = 'S34J55x'
+6 = 'Built-in'
+7 = 'Built-in'
+8 = 'Built-in'
+9 = 'DELL U2417H'
+
 # ── Calm baseline: float everything ──────────────────────────────────────────
 # PHASE 1 keystone. This catch-all rule floats every newly-detected window, so
 # AeroSpace behaves like "virtual desktops with great keybinds" and never


### PR DESCRIPTION
## Summary

After applying Phase 1 (#75) on a 3-monitor setup, `alt+1..9` flung windows around the ultrawide instead of navigating calmly. Cause: an unassigned workspace defaults to the *main* monitor, so all of 1–9 piled onto the ultrawide (S34J55x) while the built-in and DELL held workspaces `alt+1..9` couldn't reach. This pins each workspace to a monitor so every screen gets a stable lane.

## What

`home/dot_config/aerospace/aerospace.toml` — add `[workspace-to-monitor-force-assignment]`:

| Monitor | Workspaces |
|---|---|
| S34J55x (ultrawide, main) | 1–5 |
| Built-in Retina | 6–8 |
| DELL U2417H (portrait) | 9 |

Monitors are matched by **name regex** (survives macOS renumbering); AeroSpace falls back to the main display when a monitor is absent, so an undocked laptop still reaches 1–9.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other: <!-- describe -->

## Verification

- [ ] `hk check` clean
- [ ] `./bin/test` green
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Applied on the 3-monitor machine: `aerospace reload-config` validates, and `aerospace list-workspaces --monitor N` confirms ultrawide→1-5, built-in→6-8, DELL→9
- [ ] N/A — docs/config-only change

## Notes for reviewers

Tuned to specific monitor names for this desk; the comment block documents how to adjust and the undock fallback behavior. Workspaces 10/11 are leftover auto-created extras from the pre-fix chaos — unreachable by `alt+1..9` and harmless.

## Linked work

Fixes multi-monitor behavior of Phase 1 (#75 / ADR 0007 #72).

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/77a29d4177950fb6db415d60e1149da0)