### PR TITLE
docs(aerospace): note proper monitor arrangement prerequisite :bulb:

### DIFF
--- a/home/dot_config/aerospace/aerospace.toml
+++ b/home/dot_config/aerospace/aerospace.toml
@@ -46,6 +46,16 @@ outer.top = 8
 outer.right = 8
 
 # ── Workspaces → monitors ─────────────────────────────────────────────────────
+# PREREQUISITE (macOS Display settings, not config): stagger the monitors so each
+# one keeps a free bottom corner. AeroSpace hides an inactive workspace by parking
+# its windows off-screen in a monitor's bottom-left or bottom-right corner. When two
+# displays sit flush along an edge they *share* that corner, so the parked windows
+# spill onto the neighboring screen — e.g. a portrait monitor flush against the
+# ultrawide's bottom shows the ultrawide's hidden windows along its lower edge.
+# Offset the displays (don't align their edges) so every monitor has an open bottom
+# corner to hide into. Fix the arrangement, not the config.
+# See https://nikitabobko.github.io/AeroSpace/guide#proper-monitor-arrangement
+#
 # Multi-monitor calm (Phase 1 refinement). Without this, an unassigned workspace
 # defaults to the *main* monitor, so all of 1–9 piled onto the ultrawide and
 # `alt+1..9` yanked windows around that one screen while the other two displays


### PR DESCRIPTION
## Summary

Records the multi-monitor gotcha discovered while bringing up Phase 1: AeroSpace hides an inactive workspace by parking its windows off-screen in a monitor's **bottom-left or bottom-right corner**. When two displays sit flush along an edge they *share* that corner, so the parked windows spill onto the neighboring screen — e.g. a portrait monitor flush against the ultrawide's bottom shows the ultrawide's hidden windows along its lower edge. The fix is to **stagger** the displays so each keeps a free bottom corner (macOS Display settings, not config). Adds a comment near the workspace-to-monitor block pointing at the [upstream guidance](https://nikitabobko.github.io/AeroSpace/guide#proper-monitor-arrangement).

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other: <!-- describe -->

## Verification

- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Comment-only change; `aerospace reload-config` still validates
- [ ] N/A — docs/config-only change

## Linked work

Follow-up to #77 (multi-monitor pinning) / ADR 0007 (#72). Comment-only, no behavior change.

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/77a29d4177950fb6db415d60e1149da0)