### PR TITLE
feat(aerospace): show per-monitor workspaces in sketchybar :sparkles:

### DIFF
--- a/home/dot_config/aerospace/aerospace.toml
+++ b/home/dot_config/aerospace/aerospace.toml
@@ -36,14 +36,30 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Don't fight macOS's own hide behavior.
 automatically-unhide-macos-hidden-apps = false
 
-# ── Gaps ──────────────────────────────────────────────────────────────────── (Phase 1: defined but unused while floating; tuned in Phase 3)
+# Tell sketchybar when the focused workspace changes, so the per-monitor
+# workspace pills can re-highlight (Phase 2: aerospace ↔ sketchybar). The pill
+# rendering + highlight logic lives in ~/.config/sketchybar/sketchybarrc; here we
+# only fire the event carrying the now-focused workspace. Full path so it
+# resolves under AeroSpace's launchd environment.
+exec-on-workspace-change = ['/bin/bash', '-c',
+  '/opt/homebrew/bin/sketchybar --trigger aerospace_workspace_change FOCUSED=$AEROSPACE_FOCUSED_WORKSPACE',
+]
+
+# ── Gaps ──────────────────────────────────────────────────────────────────── (Phase 1: outer gaps unused while floating; tuned in Phase 3)
 [gaps]
 inner.horizontal = 8
 inner.vertical = 8
 outer.left = 8
 outer.bottom = 8
-outer.top = 8
 outer.right = 8
+# Reserve room for the sketchybar bar (top, 30px) so tiled windows don't sit under
+# it. Per-monitor: the built-in's notch menu bar is already taller than the bar, so
+# it needs only the normal 8px gap; external displays have a ~24px menu bar, so the
+# 30px bar overhangs the tiling area — we add the overflow on top of the 8px gap.
+# NOTE: only takes effect once a workspace TILES (Phase 1 floats everything, and
+# AeroSpace never repositions floating windows). The external value is a starting
+# estimate — fine-tune it the first time a workspace tiles and we can see the edge.
+outer.top = [{ monitor."Built-in Retina Display" = 8 }, 14]
 
 # ── Workspaces → monitors ─────────────────────────────────────────────────────
 # PREREQUISITE (macOS Display settings, not config): stagger the monitors so each

--- a/home/dot_config/sketchybar/executable_sketchybarrc
+++ b/home/dot_config/sketchybar/executable_sketchybarrc
@@ -82,6 +82,68 @@ sbar.default({
   padding_right = 3,
 })
 
+-- ── AeroSpace workspaces (left) ──────────────────────────────────────────────
+-- Per-monitor lanes: each display's bar shows only the workspaces AeroSpace pins
+-- to that monitor (see workspace-to-monitor-force-assignment in aerospace.toml:
+-- ultrawide 1-5 · built-in 6-8 · DELL 9). sketchybar's `display` number is the
+-- AppKit NSScreen id, which AeroSpace also reports per monitor — so we map
+-- workspace → monitor → NSScreen dynamically and survive macOS renumbering the
+-- displays, rather than hardcoding fragile display numbers. AeroSpace fires the
+-- `aerospace_workspace_change` event on every switch (exec-on-workspace-change
+-- in aerospace.toml). Rearranging monitors needs a `sketchybar --reload` to
+-- recompute the mapping.
+local AEROSPACE = "/opt/homebrew/bin/aerospace"
+
+local function aerospace(args)
+  local handle = io.popen(AEROSPACE .. " " .. args .. " 2>/dev/null")
+  if not handle then return "" end
+  local out = handle:read("*a") or ""
+  handle:close()
+  return out
+end
+
+-- monitor-id → sketchybar display (NSScreen) number
+local monitor_to_display = {}
+for mid, ns in aerospace(
+  "list-monitors --format '%{monitor-id} %{monitor-appkit-nsscreen-screens-id}'"
+):gmatch("(%d+)%s+(%d+)") do
+  monitor_to_display[mid] = tonumber(ns)
+end
+
+-- One pill per workspace, pinned to its monitor's bar. Clicking it switches.
+local workspace_items = {}
+for mid, display in pairs(monitor_to_display) do
+  for ws in aerospace("list-workspaces --monitor " .. mid):gmatch("%S+") do
+    workspace_items[ws] = sbar.add("item", "space." .. ws, {
+      position     = "left",
+      display      = display,
+      icon         = { drawing = "off" },
+      label        = { string = ws, font = FONT_ICON, padding_left = 8, padding_right = 8 },
+      click_script = AEROSPACE .. " workspace " .. ws,
+    })
+  end
+end
+
+-- Highlight the workspace currently visible on each monitor (one pill per bar).
+local function update_workspaces()
+  local visible = {}
+  for ws in aerospace("list-workspaces --visible --monitor all"):gmatch("%S+") do
+    visible[ws] = true
+  end
+  for ws, item in pairs(workspace_items) do
+    if visible[ws] then
+      item:set({ label = { color = colors.bar }, background = { color = colors.accent } })
+    else
+      item:set({ label = { color = colors.fg }, background = { color = colors.item_bg } })
+    end
+  end
+end
+
+-- A single hidden controller drives the global refresh on each workspace change.
+sbar.add("event", "aerospace_workspace_change")
+sbar.add("item", "spaces.controller", { drawing = "off" })
+  :subscribe({ "aerospace_workspace_change", "system_woke" }, update_workspaces)
+
 -- ── right side (added right-to-left in render order) ────────────────────────
 
 -- battery — pixel-block icon scales with charge; charging swaps to a bolt.
@@ -161,6 +223,7 @@ clock:subscribe("routine", update_clock)
 -- Render once immediately so items show before their first periodic tick.
 update_battery()
 update_clock()
+update_workspaces()
 
 sbar.update()
 


### PR DESCRIPTION
## Summary

First slice of the AeroSpace ↔ sketchybar integration: workspace pills in the bar, plus reserving top-bar space so tiled windows won't cover it. AeroSpace fires `aerospace_workspace_change` on every switch; sketchybar renders **per-monitor lanes** — each display's bar shows only the workspaces pinned to that monitor (ultrawide 1–5, built-in 6–8, DELL 9), with the visible workspace highlighted and click-to-switch.

## What

- `home/dot_config/aerospace/aerospace.toml`
  - `exec-on-workspace-change` → `sketchybar --trigger aerospace_workspace_change FOCUSED=$AEROSPACE_FOCUSED_WORKSPACE`
  - `gaps.outer.top` becomes per-monitor: `[{ monitor."Built-in Retina Display" = 8 }, 14]` to reserve room for the 30px bar.
- `home/dot_config/sketchybar/executable_sketchybarrc`
  - Per-workspace pills on the left, each pinned to its monitor's bar via sketchybar `display`.
  - Mapping workspace → monitor → bar is derived from AeroSpace's **AppKit NSScreen id** (= sketchybar's `display` number), so it survives macOS renumbering displays. AeroSpace monitor ids and sketchybar display ids genuinely differ here (DELL is AeroSpace monitor 1 but display 3), so a hardcoded mapping would have been wrong.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate
- [ ] Claude Code config (`home/dot_claude/`)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other

## Verification

- [x] `chezmoi diff` previewed; only the two intended paths changed
- [x] Applied on the 3-monitor machine: `aerospace reload-config` and `sketchybar --reload` both succeed; `luac -p` validates the Lua
- [x] `associated_display_mask` confirms pills land on the right bars (1–5→ultrawide, 6–8→built-in, 9→DELL)
- [x] Firing `aerospace_workspace_change` re-highlights the visible workspace per monitor (1/6/9 accent, others dim)

## Notes for reviewers

The `gaps.outer.top` reservation **only takes effect once a workspace tiles** — Phase 1 floats everything and AeroSpace never repositions floating windows. The external value (14px) is a starting estimate to fine-tune the first time a workspace tiles and the bar edge is observable. Rearranging monitors needs a `sketchybar --reload` to recompute the NSScreen mapping (noted inline).

## Linked work

Pulls the sketchybar integration (originally Phase 5 in ADR 0007 #72) forward; complements the workspace-to-monitor pinning from #77.

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/77a29d4177950fb6db415d60e1149da0)