### PR TITLE
feat(sketchybar): add frontmost app name and icon to left side of bar :relieved:

### DIFF
--- a/home/.chezmoiexternals/sketchybar.toml
+++ b/home/.chezmoiexternals/sketchybar.toml
@@ -1,0 +1,10 @@
+# sketchybar-app-font — app icon glyphs for sketchybar
+["Library/Fonts/sketchybar-app-font.ttf"]
+    type = "file"
+    url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v2.0.62/sketchybar-app-font.ttf"
+    refreshPeriod = "168h"
+
+[".config/sketchybar/icon_map.sh"]
+    type = "file"
+    url = "https://github.com/kvndrsslr/sketchybar-app-font/releases/download/v2.0.62/icon_map.sh"
+    refreshPeriod = "168h"

--- a/home/dot_config/sketchybar/executable_sketchybarrc
+++ b/home/dot_config/sketchybar/executable_sketchybarrc
@@ -53,6 +53,15 @@ sketchybar --default updates=when_shown \
                      padding_left=3 \
                      padding_right=3
 
+# ── left side ──────────────────────────────────────────────────────────────
+
+# front_app — frontmost app icon + name
+sketchybar --add item front_app left \
+           --set  front_app \
+                  label.padding_left=6 \
+                  script="$PLUGIN_DIR/front_app.sh" \
+           --subscribe front_app front_app_switched
+
 # ── right side (added right-to-left in render order) ───────────────────────
 
 # battery — pixel-block icon scales with charge

--- a/home/dot_config/sketchybar/plugins/executable_front_app.sh
+++ b/home/dot_config/sketchybar/plugins/executable_front_app.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# front_app — show the frontmost application's icon (app font glyph) and name.
+#
+# icon_map.sh is managed by chezmoi externals (home/.chezmoiexternals/sketchybar.toml)
+# and sets $ICON for a given app name.
+
+set -eu
+
+# shellcheck source=/dev/null
+source "$HOME/.config/sketchybar/icon_map.sh"
+
+APP="${FRONT_APP:-}"
+if [ -z "$APP" ]; then
+  APP=$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null) || true
+fi
+
+[ -z "$APP" ] && exit 0
+
+icon_map "$APP"
+
+sketchybar --set "$NAME" \
+           icon.font="sketchybar-app-font:Regular:16.0" \
+           icon="$ICON" \
+           label="$APP"


### PR DESCRIPTION
## Summary

Add the frontmost application's name and icon to the left side of the sketchybar. Uses sketchybar-app-font (v2.0.62) for per-app glyphs — `icon.image` doesn't exist in sketchybar v2.23.0, so the font-based approach is the right call here. The font and `icon_map.sh` helper are managed as chezmoi externals so `chezmoi apply` handles installation automatically.

> **Note for future Renovate work:** `home/.chezmoiexternals/sketchybar.toml` uses a GitHub release download URL format that may not be covered by an existing custom manager in `renovate.json5`. Version bumps will need a new rule or manual updates until that's wired up.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other: <!-- describe -->

## Verification

- [ ] `hk check` clean
- [ ] `./bin/test` green (set `CI=1 GITHUB_ACTIONS=1` if your change touches a chezmoi template that branches on CI)
- [x] `chezmoi diff` previewed and only intended paths changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [ ] N/A — docs/config-only change

## Linked work

none

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/4f970311a02f901472ca4ca46bf92798)