### PR TITLE
feat(pr): never gist conversation logs from blocklisted repos :relieved:

### DIFF
--- a/home/.chezmoidata/pr.yaml
+++ b/home/.chezmoidata/pr.yaml
@@ -18,5 +18,4 @@
 # shim at `chezmoi apply` time. Edit here, never the generated script.
 pr:
   gist_remote_blocklist:
-    - "*gusto-systems.com*"
     - "*github.com/gusto/*"

--- a/home/.chezmoidata/pr.yaml
+++ b/home/.chezmoidata/pr.yaml
@@ -1,0 +1,22 @@
+# Configuration for the `/pr` skill (home/dot_claude/skills/pr/).
+#
+# `gist_remote_blocklist` lists git-remote patterns for repositories whose
+# conversation logs must NEVER leave the machine. When the repo behind the
+# current working directory has a remote matching any of these, the `/pr`
+# skill skips session extraction, skips the secret Gist, and omits the
+# conversation-log link from the PR body entirely.
+#
+# Matching (see executable_claude-session-gist.tmpl):
+#   - Each of the repo's git remotes is normalized to a canonical
+#     `host/org/repo` form (scheme, `user@`, and the scp-style `:` are
+#     stripped) and lowercased.
+#   - Patterns are shell globs (`*` wildcards) matched case-insensitively
+#     against that normalized form. So `*github.com/gusto/*` matches both the
+#     HTTPS and SSH remotes for github.com/Gusto/<repo>.
+#
+# This file is the single source of truth; the patterns are rendered into the
+# shim at `chezmoi apply` time. Edit here, never the generated script.
+pr:
+  gist_remote_blocklist:
+    - "*gusto-systems.com*"
+    - "*github.com/gusto/*"

--- a/home/dot_claude/skills/pr/SKILL.md
+++ b/home/dot_claude/skills/pr/SKILL.md
@@ -6,7 +6,7 @@ model: sonnet
 allowed-tools:
   - Glob
   - Read
-  - Bash(~/.claude/skills/pr/claude-extract-session:*)
+  - Bash(~/.claude/skills/pr/claude-session-gist:*)
 ---
 
 # Create Pull Request
@@ -87,26 +87,31 @@ Palette (use these or any GitHub emoji that fits):
 🤖 [Conversation log](GIST_URL)
 ```
 
+The trailing horizontal rule and `🤖 [Conversation log]` line are **conditional** — include them only if the gist step in 3.1 actually produced a URL. For blocklisted repositories (see below), omit both entirely.
+
 If user provided additional context in arguments, incorporate it appropriately into the PR body.
 
 Draft the content but don't show it to the user for approval - proceed directly to creation.
 
 ### 3.1 Export Conversation Log and Create Gist
 
-Export **only the current session** and pipe directly to a secret Gist:
+Publish the current session through the gist shim, which extracts **only the current session** and pipes it to a secret Gist:
 
 ```bash
-~/.claude/skills/pr/claude-extract-session "${CLAUDE_SESSION_ID}" \
-  | gh gist create --filename "pr-conversation-<branch-name>.md" -
+~/.claude/skills/pr/claude-session-gist "${CLAUDE_SESSION_ID}"
 ```
 
 The shim:
 - Takes the current session ID (provided by the `${CLAUDE_SESSION_ID}` substitution)
-- Extracts **only that session** with `--detailed` output
-- Writes markdown to stdout (no files created on disk)
-- Pipes directly to `gh gist create` (secret by default)
+- **Checks the current repo's git remote against the gist blocklist first** (work repos whose conversation logs must never leave the machine — defined in `home/.chezmoidata/pr.yaml`, rendered into the shim at `chezmoi apply` time)
+- For a **blocklisted** repo: refuses before extracting or uploading anything — prints an explanation to stderr, exits `3`, and writes **nothing to stdout**
+- Otherwise: extracts with `--detailed` output, pipes directly to `gh gist create` (secret by default), and prints **only the Gist URL** to stdout
 
-Capture the Gist URL from the output and include it in the PR body after the horizontal rule.
+**Handle the result:**
+- **Got a URL on stdout** → include it in the PR body after the horizontal rule.
+- **Exit code 3 / no URL** → the repo is blocklisted. Do **not** retry, do **not** attempt extraction another way. Omit the horizontal rule and `🤖 [Conversation log]` line from the PR body, and note in the final report that the conversation log was skipped because this repository is on the gist blocklist.
+
+This is a hard guarantee enforced by the shim, not just a guideline — never work around it.
 
 ### 4. Push and Create PR
 

--- a/home/dot_claude/skills/pr/executable_claude-session-gist.tmpl
+++ b/home/dot_claude/skills/pr/executable_claude-session-gist.tmpl
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# claude-session-gist - Publish the current Claude session as a secret Gist,
+# UNLESS the current repository's git remote is on the blocklist.
+#
+# Usage: claude-session-gist <session-id> [branch-name]
+#
+# Behavior:
+#   - If any git remote of the current repo matches a blocked pattern, this
+#     refuses BEFORE extracting or uploading anything: it prints an
+#     explanation to stderr and exits 3 with NO stdout. The caller MUST then
+#     omit the conversation-log link from the PR body.
+#   - Otherwise it extracts the session (via the sibling claude-extract-session
+#     shim) and pipes it to `gh gist create` (secret by default), printing the
+#     resulting Gist URL — and nothing else — to stdout.
+#
+# The blocklist is rendered from home/.chezmoidata/pr.yaml at `chezmoi apply`
+# time. Edit the patterns there, never in the generated script.
+
+[[ -n "${DEBUG:-}" ]] && set -o xtrace
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+
+readonly SCRIPT_NAME="${0##*/}"
+readonly SCRIPT_DIR="${0%/*}"
+readonly EXIT_BLOCKED=3
+
+# Remote patterns whose repositories must never have their conversation logs
+# extracted or published. Rendered from home/.chezmoidata/pr.yaml.
+readonly BLOCKED_REMOTE_PATTERNS=(
+{{- range .pr.gist_remote_blocklist }}
+    {{ . | quote }}
+{{- end }}
+)
+
+# Print message to stderr
+log() {
+    printf '%s: %s\n' "${SCRIPT_NAME}" "$*" >&2
+}
+
+# Print error and exit
+die() {
+    log "error: $*"
+    exit 1
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage: ${SCRIPT_NAME} <session-id> [branch-name]
+
+Publish the current Claude session as a secret Gist, unless the current
+repository's git remote is on the gist blocklist.
+
+Arguments:
+    session-id    UUID or agent-prefixed ID of the session to publish
+    branch-name   Optional; defaults to the current branch. Used only to name
+                  the Gist file.
+
+Options:
+    -h, --help    Show this help message
+
+Exit codes:
+    0   Gist created; URL printed to stdout
+    3   Repository is blocklisted; nothing extracted or uploaded
+    1   Error
+EOF
+    exit 1
+}
+
+# Normalize a git remote URL to a canonical, lowercased `host/org/repo` form so
+# that HTTPS and scp-style SSH remotes for the same repo compare equal.
+#   https://github.com/Gusto/repo.git -> github.com/gusto/repo.git
+#   git@github.com:Gusto/repo.git     -> github.com/gusto/repo.git
+#   ssh://git@github.com/Gusto/repo   -> github.com/gusto/repo
+normalize_remote() {
+    local url="$1"
+    local sep='/'
+
+    url="${url#*://}"      # strip scheme://
+    url="${url#*@}"        # strip user@
+    url="${url/:/$sep}"    # scp-style host:path -> host/path
+    printf '%s' "${url,,}" # lowercase
+}
+
+# Return 0 if the current repo has any remote matching the blocklist.
+repo_is_blocked() {
+    # No patterns configured -> nothing is ever blocked.
+    if [[ "${#BLOCKED_REMOTE_PATTERNS[@]}" -eq 0 ]]; then
+        return 1
+    fi
+
+    # Not a git repo (or no remotes) -> nothing to match against.
+    local remotes
+    if ! remotes=$(git remote 2>/dev/null) || [[ -z "${remotes}" ]]; then
+        return 1
+    fi
+
+    local remote url norm pattern
+    while IFS= read -r remote; do
+        [[ -z "${remote}" ]] && continue
+        url=$(git remote get-url "${remote}" 2>/dev/null) || continue
+        norm=$(normalize_remote "${url}")
+        for pattern in "${BLOCKED_REMOTE_PATTERNS[@]}"; do
+            # shellcheck disable=SC2053 # intentional glob match
+            if [[ "${norm}" == "${pattern,,}" ]]; then
+                log "blocked: remote '${url}' matches pattern '${pattern}'"
+                return 0
+            fi
+        done
+    done <<< "${remotes}"
+
+    return 1
+}
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+    fi
+
+    if [[ $# -lt 1 || $# -gt 2 ]]; then
+        die "expected 1-2 arguments, got $#. Use --help for usage."
+    fi
+
+    local session_id="$1"
+    local branch="${2:-}"
+
+    # Refuse before touching the session for blocklisted repositories.
+    if repo_is_blocked; then
+        log "this repository's conversation log must not be published; skipping gist."
+        exit "${EXIT_BLOCKED}"
+    fi
+
+    if [[ -z "${branch}" ]]; then
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'session')
+    fi
+    # Slashes are illegal in Gist filenames; flatten branch names like fix/foo.
+    local branch_safe="${branch//\//-}"
+
+    local extract="${SCRIPT_DIR}/claude-extract-session"
+    [[ -x "${extract}" ]] || die "sibling shim not found or not executable: ${extract}"
+
+    command -v gh &>/dev/null || die "gh not found in PATH"
+
+    # Extract -> secret Gist. gh prints the Gist URL to stdout, which becomes
+    # this script's only stdout.
+    "${extract}" "${session_id}" \
+        | gh gist create --filename "pr-conversation-${branch_safe}.md" -
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

The `/pr` skill extracts the current session and uploads it to a secret Gist linked from the PR body. For work repositories that conversation log must never leave the machine. This adds a hard, script-enforced gate so a misbehaving model can't leak it — and keeps the blocklist as a single source of truth in chezmoidata.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [ ] `hk check` clean
- [ ] `./bin/test` green
- [x] `chezmoi diff` previewed and only intended paths changed (then `chezmoi apply`'d; `chezmoi status` clean)
- [x] Template renders verified — rendered `executable_claude-session-gist.tmpl` is `shellcheck`-clean; remote-matching tested (Gusto HTTPS/SSH → blocked, personal/OSS → allowed); shim ran end-to-end and produced a gist URL
- [ ] N/A — docs/config-only change

<!-- gitleaks not installed locally — CI will check -->

## Linked work

none

### How it works

- **`home/.chezmoidata/pr.yaml`** — single source of truth: a `gist_remote_blocklist` of glob patterns (seeded with `*github.com/gusto/*`).
- **`home/dot_claude/skills/pr/executable_claude-session-gist.tmpl`** — new gate shim. The blocklist is rendered into it at `chezmoi apply` time. At runtime it normalizes every git remote of the cwd to a canonical lowercased `host/org/repo` form (so HTTPS and scp-style SSH compare equal), matches against the blocklist, and **refuses before extracting or uploading** when matched — exits `3` with no stdout. Otherwise it extracts + gists and prints only the URL.
- **`SKILL.md`** — routes the gist step through the shim and makes the conversation-log link conditional on a URL coming back.

## Notes for reviewers

- **Enforcement in the script, not just instructions** — SKILL.md guidance can be ignored by the model; the script gate cannot. The shim owns the dangerous path (`gh gist create`) entirely.
- **One source of truth** — deliberately did *not* template SKILL.md. The list lives only in chezmoidata → baked into the shim. SKILL.md stays plain markdown describing the behavior generically, so the list can't drift between two files.
- **Match by remote, not path** — catches work repos wherever they're checked out. Repos with no remote (or non-git dirs) are treated as allowed, since there's nothing to match against and blocking them would break the common personal-repo case.

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/468530237e6f30af32686bedd9930c39)