### PR TITLE
fix(pr): unquote glob so the gist blocklist actually matches :bug:

### DIFF
--- a/home/dot_claude/skills/pr/executable_claude-session-gist.tmpl
+++ b/home/dot_claude/skills/pr/executable_claude-session-gist.tmpl
@@ -103,8 +103,12 @@ repo_is_blocked() {
         url=$(git remote get-url "${remote}" 2>/dev/null) || continue
         norm=$(normalize_remote "${url}")
         for pattern in "${BLOCKED_REMOTE_PATTERNS[@]}"; do
+            # RHS must stay UNQUOTED so [[ == ]] treats it as a glob, not a
+            # literal; quoting it silently turns the blocklist into exact-match
+            # and lets work repos through.
+            local pattern_lc="${pattern,,}"
             # shellcheck disable=SC2053 # intentional glob match
-            if [[ "${norm}" == "${pattern,,}" ]]; then
+            if [[ "${norm}" == ${pattern_lc} ]]; then
                 log "blocked: remote '${url}' matches pattern '${pattern}'"
                 return 0
             fi


### PR DESCRIPTION
## Why

The conversation-log gist blocklist added in #81 silently failed. In `repo_is_blocked`, the normalized remote was compared against a **quoted** pattern in `[[ "$norm" == "$pattern" ]]`. Quoting the right-hand side of `==` disables glob matching, turning it into an exact-string compare — so `*github.com/gusto/*` never matched a real remote like `github.com/gusto/wtf-everywhere.git`, and work-repo conversation logs were being gisted despite being blocklisted.

## What

Lowercase the pattern into a variable and leave it **unquoted** on the RHS so `[[ == ]]` does glob matching again.

## Notes for reviewers

- Verified against the deployed shim: in a `git@github.com:Gusto/...` checkout the shim now exits `3` (`blocked: ... matches pattern '*github.com/gusto/*'`) and uploads nothing.
- This bug leaked at least one real work-repo conversation log in practice (since deleted).
- No shell-test harness exists for the skill shims yet, so verification was manual. A bats regression test (render the shim, assert `repo_is_blocked` for blocklisted vs allowed remotes) would be a good follow-up but is net-new infra.
- No conversation-log link on this PR on purpose: the originating session is work-repo content, which is exactly what the blocklist exists to keep off gists.