### PR TITLE
chore(git): ignore local .bk.yaml Buildkite config :see_no_evil:

### DIFF
--- a/home/dot_config/git/ignore
+++ b/home/dot_config/git/ignore
@@ -95,3 +95,6 @@ node_modules/
 
 # Databases
 *.db
+
+# Buildkite local configuration
+.bk.yaml


### PR DESCRIPTION
## Summary

The Buildkite CLI writes a checkout-local `.bk.yaml` into the working tree. Ignore it via the global git ignore so it never shows up as untracked noise in any repo.

## Scope

- [x] Chezmoi source (`home/`)

## Verification

- [x] N/A — config-only change (single line added to `home/dot_config/git/ignore`)
- `hk` / `./bin/test` not run locally — trivial gitignore addition; CI will cover.

## Linked work

none