### PR TITLE
feat(nvim): editor ergonomics — keymaps, folds, statusline :nail_care:

### DIFF
--- a/home/dot_config/nvim/lua/autocmds.lua
+++ b/home/dot_config/nvim/lua/autocmds.lua
@@ -12,3 +12,14 @@ vim.api.nvim_create_autocmd("BufWritePre", {
     vim.cmd([[%s/\s\+$//e]])
   end,
 })
+
+-- Create missing directories on save
+vim.api.nvim_create_autocmd("BufWritePre", {
+  pattern = "*",
+  callback = function(args)
+    local dir = vim.fn.fnamemodify(args.file, ":h")
+    if vim.fn.isdirectory(dir) == 0 then
+      vim.fn.mkdir(dir, "p")
+    end
+  end,
+})

--- a/home/dot_config/nvim/lua/keymaps.lua
+++ b/home/dot_config/nvim/lua/keymaps.lua
@@ -7,10 +7,27 @@ local function fugitive(command)
   end
 end
 
-map("v", "<", "<gv")
-map("v", ">", ">gv")
-map("n", "<Esc>", "<cmd>nohlsearch<cr>", { desc = "Clear search highlight" })
-map("n", "<C-f>", "<cmd>silent !tmux neww tmux-sessionizer.sh<CR>", { desc = "Tmux sessionizer" })
+map("i", "jk", "<Esc>", { noremap = true, desc = "Exit insert mode" })
+
+-- Window navigation
+map("n", "<C-J>", "<C-W><C-J>", { desc = "Move to the window below" })
+map("n", "<C-K>", "<C-W><C-K>", { desc = "Move to the window above" })
+map("n", "<C-H>", "<C-W><C-H>", { desc = "Move to the window left" })
+map("n", "<C-L>", "<C-W><C-L>", { desc = "Move to the window right" })
+
+-- Clear highlights
+map("n", "<C-S>", ":nohlsearch<CR>", { noremap = true, silent = true, desc = "Clear search highlights" })
+
+-- Buffer navigation
+map("n", "]b", ":bprevious<CR>", { noremap = true, silent = true, desc = "Go to previous buffer" })
+map("n", "[b", ":bnext<CR>", { noremap = true, silent = true, desc = "Go to next buffer" })
+
+-- Toggle relative line numbers
+map("n", "<leader>r", ":set rnu!<CR>", { noremap = true, silent = true, desc = "Toggle relative line numbers" })
+
+-- %% expands to current file directory
+vim.cmd([[cnoremap <expr> %% getcmdtype() == ':' ? expand('%:h').'/' : '%%']])
+
 map("n", "<leader>gs", fugitive("Git"), { desc = "Git status" })
 map("n", "<leader>gb", fugitive("Git blame"), { desc = "Git blame" })
 map("n", "<leader>gd", fugitive("Gvdiffsplit"), { desc = "Git diff" })

--- a/home/dot_config/nvim/lua/options.lua
+++ b/home/dot_config/nvim/lua/options.lua
@@ -3,13 +3,11 @@
 -- security
 vim.opt.modelines = 0
 
--- set leader key to comma
-vim.g.mapleader = ","
-
 -- hide buffers, not close them
 vim.opt.hidden = true
 
 -- maintain undo history between sessions
+vim.opt.history = 1000
 vim.opt.swapfile = false
 vim.opt.undofile = true
 vim.opt.undodir = vim.fn.stdpath("data") .. "/undo"
@@ -55,8 +53,7 @@ vim.opt.inccommand = "split"
 -- use indents of 2
 vim.opt.shiftwidth = 2
 
--- tabs are tabs
-vim.opt.expandtab = false
+vim.opt.expandtab = true
 
 -- an indentation every 2 columns
 vim.opt.tabstop = 2
@@ -66,3 +63,11 @@ vim.opt.softtabstop = 2
 
 -- enable auto indentation
 vim.opt.autoindent = true
+
+vim.opt.foldmethod = "expr"
+vim.opt.foldexpr = "v:lua.vim.treesitter.foldexpr()"
+vim.opt.foldlevel = 99
+
+vim.opt.autocomplete = true
+vim.cmd.packadd("nvim.undotree")
+vim.cmd.packadd("nvim.difftool")

--- a/home/dot_config/nvim/lua/ui.lua
+++ b/home/dot_config/nvim/lua/ui.lua
@@ -1,6 +1,7 @@
 local o = vim.opt
 
 o.showmatch = true
+o.showcmd = true
 o.cmdheight = 1
 o.signcolumn = "auto:2"
 o.termguicolors = true
@@ -17,6 +18,8 @@ o.list = true
 o.fillchars = { vert = "▒" }
 o.splitbelow = true
 o.splitright = true
+
+o.pumborder = "single"
 
 -- custom tabline
 local noname = "[unnamed]"

--- a/home/dot_config/nvim/plugin/lualine.lua
+++ b/home/dot_config/nvim/plugin/lualine.lua
@@ -1,1 +1,27 @@
-require("lualine").setup()
+require("lualine").setup({
+  sections = {
+    lualine_a = { "mode" },
+    lualine_b = { "branch", "diff", "diagnostics" },
+    lualine_c = { "filename" },
+    lualine_x = { "encoding", "fileformat", "filetype" },
+    lualine_y = { "progress" },
+    lualine_z = {
+      "location",
+      {
+        function()
+          return vim.fn.reg_recording() ~= "" and "recording @" .. vim.fn.reg_recording() or ""
+        end,
+        cond = function()
+          return vim.fn.reg_recording() ~= ""
+        end,
+      },
+    },
+  },
+  options = {
+    globalstatus = true,
+  },
+})
+
+vim.opt.laststatus = 3
+
+require("nvim-web-devicons").setup()

--- a/home/dot_config/nvim/plugin/oil.lua
+++ b/home/dot_config/nvim/plugin/oil.lua
@@ -1,3 +1,3 @@
 require("oil").setup()
 
-vim.keymap.set("n", "<leader>e", "<CMD>Oil<CR>", { desc = "Open Oil" })
+vim.keymap.set("n", "-", "<CMD>Oil<CR>", { desc = "Open Oil" })

--- a/home/dot_config/nvim/plugin/treesitter.lua
+++ b/home/dot_config/nvim/plugin/treesitter.lua
@@ -1,5 +1,13 @@
 local parsers = {
+  "ruby",
+  "tsx",
+  "c",
+  "cpp",
+  "go",
+  "elixir",
   "lua",
+  "vim",
+  "vimdoc",
   "python",
   "typescript",
   "javascript",
@@ -15,6 +23,8 @@ vim.cmd.packadd("nvim-treesitter")
 
 require("nvim-treesitter").setup({
   install_dir = vim.fn.stdpath("data") .. "/site",
+  highlight = { enable = true },
+  indent = { enable = true },
 })
 
 local installed = {}


### PR DESCRIPTION
## Summary

Editor-only ergonomics for the Neovim config — **no new plugins**. Switches to spaces + treesitter folding, drops the redundant `mapleader` override (init.lua already sets `<Space>`), adds window/buffer/insert keymaps, auto-creates missing parent dirs on save, fleshes out the lualine statusline, and maps Oil to `-`.

## Scope

- [x] Chezmoi source (`home/`)

## Verification

- [x] N/A — Neovim runtime config (Lua), not a chezmoi template or shell script. These are my in-use editor settings.
- `hk check` / `./bin/test` not run locally — repo CI (ShellCheck, BATS, install matrix) doesn't exercise nvim Lua.

## Linked work

none