### PR TITLE
feat(nvim): AI tooling, LSP servers, and editing plugins :rocket:

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -9,3 +9,4 @@ Library/**
 .oh-my-zsh/log/
 
 .claude/skills/skill-optimization-workspace/**
+.config/nvim/nvim-pack-lock.json

--- a/home/dot_config/nvim/nvim-pack-lock.json
+++ b/home/dot_config/nvim/nvim-pack-lock.json
@@ -1,5 +1,13 @@
 {
   "plugins": {
+    "CopilotChat": {
+      "rev": "ab5cf12ea8b8c8af82feb616bf7fbac096edc0e0",
+      "src": "https://github.com/CopilotC-Nvim/CopilotChat.nvim"
+    },
+    "avante.nvim": {
+      "rev": "dee2402ed0b7c1d3710c0c8eed3d26aa055e118e",
+      "src": "https://github.com/yetone/avante.nvim"
+    },
     "blink.cmp": {
       "rev": "49f211fe5d729df53df4c042d7c3464cf47d199e",
       "src": "https://github.com/Saghen/blink.cmp",
@@ -12,6 +20,26 @@
     "citruszest.nvim": {
       "rev": "e6fed9ec3d0ac190b1387379c138ba5e23a1f4f9",
       "src": "https://github.com/zootedb0t/citruszest.nvim"
+    },
+    "claudecode": {
+      "rev": "e6c9dd4d4f144910b0066489100ad94b7133821f",
+      "src": "https://github.com/coder/claudecode.nvim"
+    },
+    "conform.nvim": {
+      "rev": "619363c30309d29ffa631e67c8183f2a72caa373",
+      "src": "https://github.com/stevearc/conform.nvim"
+    },
+    "copilot": {
+      "rev": "a12fd5672110c8aa7e3c8419e28c96943ca179be",
+      "src": "https://github.com/github/copilot.vim"
+    },
+    "copilot-lua": {
+      "rev": "b54c05349d406f7af11b150824efa8e4f90015c6",
+      "src": "https://github.com/zbirenbaum/copilot.lua"
+    },
+    "dressing": {
+      "rev": "2d7c2db2507fa3c4956142ee607431ddb2828639",
+      "src": "https://github.com/stevearc/dressing.nvim"
     },
     "evangelion.nvim": {
       "rev": "08cf52a0931a81bf5b64c93b744e136b5edb6d85",
@@ -38,6 +66,10 @@
       "src": "https://github.com/ThePrimeagen/harpoon",
       "version": "'harpoon2'"
     },
+    "img-clip": {
+      "rev": "b6ddfb97b5600d99afe3452d707444afda658aca",
+      "src": "https://github.com/HakonHarnes/img-clip.nvim"
+    },
     "kanagawa.nvim": {
       "rev": "bb85e4bfc8d89b0e62c8fa53ccdd13d12e2f77b3",
       "src": "https://github.com/rebelot/kanagawa.nvim"
@@ -54,6 +86,14 @@
       "rev": "627f2e1cac91de0d1d4dd7472b506a30f41b2b7d",
       "src": "https://github.com/xero/miasma.nvim"
     },
+    "mini.indentscope": {
+      "rev": "98453149c3394ca3d1bf252e838e4777573b63e2",
+      "src": "https://github.com/echasnovski/mini.indentscope"
+    },
+    "mini.surround": {
+      "rev": "d401c3856585473693e5ce9ec4c8e5b608b4c0fe",
+      "src": "https://github.com/echasnovski/mini.surround"
+    },
     "neovim": {
       "rev": "ff483051a47e27d84bdef47703538df1ed9f4a47",
       "src": "https://github.com/rose-pine/neovim"
@@ -66,9 +106,17 @@
       "rev": "26b61b1f856ec37cae3cb64f5690adb955f246a1",
       "src": "https://github.com/EdenEast/nightfox.nvim"
     },
+    "nui": {
+      "rev": "de740991c12411b663994b2860f1a4fd0937c130",
+      "src": "https://github.com/MunifTanjim/nui.nvim"
+    },
     "nvim": {
       "rev": "426dbebe06b5c69fd846ceb17b42e12f890aedf1",
       "src": "https://github.com/catppuccin/nvim"
+    },
+    "nvim-autopairs": {
+      "rev": "7b9923abad60b903ece7c52940e1321d39eccc79",
+      "src": "https://github.com/windwp/nvim-autopairs"
     },
     "nvim-treesitter": {
       "rev": "4916d6592ede8c07973490d9322f187e07dfefac",
@@ -87,9 +135,25 @@
       "rev": "df4792accde9db0043121f32628bcf8e645d9aea",
       "src": "https://github.com/navarasu/onedark.nvim"
     },
+    "opencode": {
+      "rev": "1c5231c69a963bcf3c321844a9f5149406a85604",
+      "src": "https://github.com/nickjvandyke/opencode.nvim"
+    },
     "plenary.nvim": {
       "rev": "74b06c6c75e4eeb3108ec01852001636d85a932b",
       "src": "https://github.com/nvim-lua/plenary.nvim"
+    },
+    "render-markdown": {
+      "rev": "5adf0895310c1904e5abfaad40a2baad7fe44a07",
+      "src": "https://github.com/MeanderingProgrammer/render-markdown.nvim"
+    },
+    "schemastore.nvim": {
+      "rev": "304d2286752923e3b0eb1ddcb3d4002a69b855ad",
+      "src": "https://github.com/b0o/schemastore.nvim"
+    },
+    "snacks": {
+      "rev": "882c996cf28183f4d63640de0b4c02ec886d01f2",
+      "src": "https://github.com/folke/snacks.nvim"
     },
     "todo-comments.nvim": {
       "rev": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668",
@@ -110,6 +174,14 @@
     "vim-fugitive": {
       "rev": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0",
       "src": "https://github.com/tpope/vim-fugitive"
+    },
+    "vim-rails": {
+      "rev": "b0a5c76f86ea214ade36ab0b811e730c3f0add67",
+      "src": "https://github.com/tpope/vim-rails"
+    },
+    "vim-rhubarb": {
+      "rev": "5496d7c94581c4c9ad7430357449bb57fc59f501",
+      "src": "https://github.com/tpope/vim-rhubarb"
     },
     "which-key.nvim": {
       "rev": "3aab2147e74890957785941f0c1ad87d0a44c15a",

--- a/home/dot_config/nvim/plugin/00-packs.lua
+++ b/home/dot_config/nvim/plugin/00-packs.lua
@@ -11,55 +11,83 @@ vim.api.nvim_create_autocmd("PackChanged", {
   end,
 })
 
+local gh = function(repo)
+  return "https://github.com/" .. repo
+end
+
 local specs = {
   -- Treesitter
-  { src = "https://github.com/nvim-treesitter/nvim-treesitter", version = "main" },
+  { src = gh("nvim-treesitter/nvim-treesitter"), version = "main" },
 
   -- Completion
-  { src = "https://github.com/Saghen/blink.cmp", version = vim.version.range("1.0") },
+  { src = gh("Saghen/blink.cmp"), version = vim.version.range("1.0") },
 
   -- Utils
-  "https://github.com/nvim-lua/plenary.nvim",
-  "https://github.com/folke/which-key.nvim",
+  gh("nvim-lua/plenary.nvim"),
+  gh("folke/which-key.nvim"),
+  gh("windwp/nvim-autopairs"),
+  gh("echasnovski/mini.surround"),
+  gh("echasnovski/mini.indentscope"),
+  gh("b0o/schemastore.nvim"),
 
-  -- Picker
-  "https://github.com/ibhagwan/fzf-lua",
+  -- Formatting
+  gh("stevearc/conform.nvim"),
+
+  -- Rails development
+  gh("tpope/vim-rails"),
+
+  -- Picker & search
+  gh("ibhagwan/fzf-lua"),
 
   -- Harpoon
-  { src = "https://github.com/ThePrimeagen/harpoon", version = "harpoon2" },
+  { src = gh("ThePrimeagen/harpoon"), version = "harpoon2" },
 
   -- Git
-  "https://github.com/lewis6991/gitsigns.nvim",
-  "https://github.com/tpope/vim-fugitive",
+  gh("lewis6991/gitsigns.nvim"),
+  gh("tpope/vim-fugitive"),
+  gh("tpope/vim-rhubarb"),
 
   -- Statusline
-  "https://github.com/nvim-tree/nvim-web-devicons", -- Dependency of lualine
-  "https://github.com/nvim-lualine/lualine.nvim",
+  gh("nvim-tree/nvim-web-devicons"), -- Dependency of lualine
+  gh("nvim-lualine/lualine.nvim"),
 
   -- File tree
-  "https://github.com/stevearc/oil.nvim",
+  gh("stevearc/oil.nvim"),
 
   -- TODO Comments
-  "https://github.com/folke/todo-comments.nvim",
+  gh("folke/todo-comments.nvim"),
+
+  -- Agentic Stuff (and their dependencies)
+  gh("yetone/avante.nvim"),
+  { src = gh("github/copilot.vim"), name = "copilot" },
+  { src = gh("CopilotC-Nvim/CopilotChat.nvim"), name = "CopilotChat" },
+  { src = gh("stevearc/dressing.nvim"), name = "dressing" },
+  { src = gh("MunifTanjim/nui.nvim"), name = "nui" },
+  { src = gh("HakonHarnes/img-clip.nvim"), name = "img-clip" },
+  { src = gh("MeanderingProgrammer/render-markdown.nvim"), name = "render-markdown" },
+  { src = gh("zbirenbaum/copilot.lua"), name = "copilot-lua" },
+  { src = gh("coder/claudecode.nvim"), name = "claudecode" },
+  { src = gh("nickjvandyke/opencode.nvim"), name = "opencode" },
+  { src = gh("folke/snacks.nvim"), name = "snacks" },
 
   -- Colorschemes
-  "https://github.com/catppuccin/nvim",
-  "https://github.com/folke/tokyonight.nvim",
-  "https://github.com/ellisonleao/gruvbox.nvim",
-  "https://github.com/rose-pine/neovim",
-  "https://github.com/xero/evangelion.nvim",
-  "https://github.com/rebelot/kanagawa.nvim",
-  "https://github.com/EdenEast/nightfox.nvim",
-  "https://github.com/navarasu/onedark.nvim",
-  "https://github.com/vague-theme/vague.nvim",
-  "https://github.com/danilo-augusto/vim-afterglow",
-  { src = "https://github.com/everviolet/nvim", name = "evergarden" },
-  "https://github.com/xero/miasma.nvim",
-  "https://github.com/trapd00r/neverland-vim-theme",
-  "https://github.com/bettervim/yugen.nvim",
-  "https://github.com/savq/melange-nvim",
-  "https://github.com/zootedb0t/citruszest.nvim",
-  "https://github.com/rockerBOO/boo-colorscheme-nvim",
+  gh("catppuccin/nvim"),
+  gh("folke/tokyonight.nvim"),
+  gh("ellisonleao/gruvbox.nvim"),
+  gh("rose-pine/neovim"),
+  gh("xero/evangelion.nvim"),
+  gh("rebelot/kanagawa.nvim"),
+  gh("EdenEast/nightfox.nvim"),
+  gh("navarasu/onedark.nvim"),
+  gh("vague-theme/vague.nvim"),
+  gh("danilo-augusto/vim-afterglow"),
+  { src = gh("everviolet/nvim"), name = "evergarden" },
+  gh("xero/miasma.nvim"),
+  gh("trapd00r/neverland-vim-theme"),
+  gh("bettervim/yugen.nvim"),
+  gh("savq/melange-nvim"),
+  gh("zootedb0t/citruszest.nvim"),
+  gh("rockerBOO/boo-colorscheme-nvim"),
 }
 
 local function spec_name(spec)
@@ -82,8 +110,18 @@ for _, plugin in ipairs(vim.pack.get()) do
   end
 end
 
+local hooks = function(ev)
+  local name, kind = ev.data.spec.name, ev.data.kind
+
+  if name == "avante" and (kind == "install" or kind == "update") then
+    vim.system({ "make" }, { cwd = ev.data.path })
+  end
+end
+
 if #stale > 0 then
   vim.pack.del(stale)
 end
 
 vim.pack.add(specs)
+
+vim.api.nvim_create_autocmd("PackChanged", { callback = hooks })

--- a/home/dot_config/nvim/plugin/agentic.lua
+++ b/home/dot_config/nvim/plugin/agentic.lua
@@ -1,0 +1,33 @@
+require('CopilotChat').setup({
+  debug = true,
+})
+
+require('avante').setup({
+  hints = { enabled = false }
+})
+
+require('render-markdown').setup({
+  file_types = { "markdown", "Avante" },
+})
+
+require("claudecode").setup()
+vim.keymap.set('n', '<Leader>ac', '<Cmd>ClaudeCode<cr>', { desc = 'Toggle Claude' })
+vim.keymap.set('n', '<leader>af', '<cmd>ClaudeCodeFocus<cr>', { desc = 'Focus Claude' })
+vim.keymap.set('n', '<leader>ar', '<cmd>ClaudeCode --resume<cr>', { desc = 'Resume Claude' })
+vim.keymap.set('n', '<leader>aC', '<cmd>ClaudeCode --continue<cr>', { desc = 'Continue Claude' })
+vim.keymap.set('n', '<leader>am', '<cmd>ClaudeCodeSelectModel<cr>', { desc = 'Select Claude model' })
+vim.keymap.set('n', '<leader>ab', '<cmd>ClaudeCodeAdd %<cr>', { desc = 'Add current buffer' })
+vim.keymap.set('v', '<leader>as', '<cmd>ClaudeCodeSend<cr>', { desc = 'Send to Claude' })
+vim.keymap.set('n', '<leader>aa', '<cmd>ClaudeCodeDiffAccept<cr>', { desc = 'Accept diff' })
+vim.keymap.set('n', '<leader>ad', '<cmd>ClaudeCodeDiffDeny<cr>', { desc = 'Deny diff' })
+
+vim.g.opencode_opts = {}
+vim.o.autoread = true
+vim.keymap.set({ 'n', 'x' }, '<leader>oa', function() require('opencode').ask('@this: ', { submit = true }) end, { desc = 'Ask opencode' })
+vim.keymap.set({ 'n', 'x' }, '<leader>os', function() require('opencode').select() end, { desc = 'Select opencode action' })
+vim.keymap.set({ 'n', 't' }, '<leader>ot', function() require('opencode').toggle() end, { desc = 'Toggle opencode' })
+vim.keymap.set({ 'n', 'x' }, '<leader>oo', function() return require('opencode').operator('@this ') end, { desc = 'Add range to opencode', expr = true })
+vim.keymap.set('n', '<leader>ol', function() return require('opencode').operator('@this ') .. '_' end, { desc = 'Add line to opencode', expr = true })
+vim.keymap.set('n', '<leader>ou', function() require('opencode').command('session.half.page.up') end, { desc = 'Scroll opencode up' })
+vim.keymap.set('n', '<leader>od', function() require('opencode').command('session.half.page.down') end, { desc = 'Scroll opencode down' })
+

--- a/home/dot_config/nvim/plugin/autopairs.lua
+++ b/home/dot_config/nvim/plugin/autopairs.lua
@@ -1,0 +1,1 @@
+require('nvim-autopairs').setup()

--- a/home/dot_config/nvim/plugin/formatting.lua
+++ b/home/dot_config/nvim/plugin/formatting.lua
@@ -1,0 +1,16 @@
+require('conform').setup({
+  formatters_by_ft = {
+    lua = { "stylua" },
+    python = { "isort", "black" },
+    rust = { "rustfmt", lsp_format = "fallback" },
+    javascript = { "prettierd", "prettier", stop_after_first = true },
+    javascriptreact = { "prettierd", "prettier", stop_after_first = true },
+    typescript = { "prettierd", "prettier", stop_after_first = true },
+    typescriptreact = { "prettierd", "prettier", stop_after_first = true },
+    ruby = { "rubocop" },
+  },
+})
+
+vim.keymap.set('n', '<leader>cf', function()
+  require('conform').format({ async = true })
+end, { desc = 'Format with conform' })

--- a/home/dot_config/nvim/plugin/lsp.lua
+++ b/home/dot_config/nvim/plugin/lsp.lua
@@ -26,13 +26,71 @@ local servers = {
   },
   ts_ls = {
     cmd = { "typescript-language-server", "--stdio" },
-    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
+    filetypes = { "javascript", "javascriptreact", "javascript.jsx", "typescript", "typescriptreact", "typescript.tsx" },
     root_markers = { "package.json", "tsconfig.json", "jsconfig.json", ".git" },
   },
   gopls = {
     cmd = { "gopls" },
     filetypes = { "go", "gomod", "gowork", "gotmpl" },
-    root_markers = { "go.work", "go.mod", ".git" },
+    root_markers = { "go.mod", "go.work", ".git" },
+    settings = {
+      gopls = {
+        analyses = {
+          unusedparams = true,
+        },
+        staticcheck = true,
+      },
+    },
+  },
+  jsonls = {
+    cmd = { "vscode-json-language-server", "--stdio" },
+    filetypes = { "json", "jsonc" },
+    root_markers = { ".git" },
+    on_attach = function(client, _)
+      client.settings = vim.tbl_deep_extend("force", client.settings or {}, {
+        json = {
+          schemas = require("schemastore").json.schemas(),
+          validate = { enable = true },
+        },
+      })
+      client.notify("workspace/didChangeConfiguration", { settings = client.settings })
+    end,
+  },
+  elixirls = {
+    cmd = { "elixir-ls" },
+    filetypes = { "elixir", "eelixir", "heex", "surface" },
+    root_markers = { "mix.exs", ".git" },
+  },
+  solargraph = {
+    cmd = { vim.fn.expand("~/.local/share/mise/shims/solargraph"), "stdio" },
+    filetypes = { "ruby" },
+    root_markers = { "Gemfile", ".git" },
+    settings = {
+      solargraph = {
+        diagnostics = true,
+        completion = true,
+        formatting = true,
+      },
+    },
+  },
+  pyright = {
+    cmd = { "pyright-langserver", "--stdio" },
+    filetypes = { "python" },
+    root_markers = { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", ".git" },
+    settings = {
+      python = {
+        analysis = {
+          autoSearchPaths = true,
+          useLibraryCodeForTypes = true,
+          diagnosticMode = "openFilesOnly",
+        },
+      },
+    },
+  },
+  clangd = {
+    cmd = { "clangd", "--background-index", "--clang-tidy" },
+    filetypes = { "c", "cpp", "objc", "objcpp", "cuda" },
+    root_markers = { "compile_commands.json", "compile_flags.txt", ".clangd", ".git" },
   },
 }
 
@@ -69,16 +127,51 @@ vim.api.nvim_create_autocmd("LspAttach", {
       vim.keymap.set("n", lhs, rhs, { buffer = buf, desc = desc })
     end
 
+    local opts = { buffer = buf }
+
+    -- Navigation
     map("gd", vim.lsp.buf.definition, "LSP: definition")
     map("gD", vim.lsp.buf.declaration, "LSP: declaration")
-    map("gr", vim.lsp.buf.references, "LSP: references")
     map("gi", vim.lsp.buf.implementation, "LSP: implementation")
+    map("gr", vim.lsp.buf.references, "LSP: references")
+    map("gy", vim.lsp.buf.type_definition, "LSP: type definition")
+
+    -- Hover and signature
     map("K", vim.lsp.buf.hover, "LSP: hover")
-    map("<Space>lr", vim.lsp.buf.rename, "LSP: rename")
-    map("<Space>la", vim.lsp.buf.code_action, "LSP: code action")
-    map("<Space>lf", function() vim.lsp.buf.format({ async = true }) end, "LSP: format")
-    map("<Space>ld", vim.diagnostic.open_float, "LSP: line diagnostics")
-    map("[d", function() vim.diagnostic.jump({ count = -1, float = true }) end, "LSP: prev diagnostic")
-    map("]d", function() vim.diagnostic.jump({ count = 1, float = true }) end, "LSP: next diagnostic")
+    vim.keymap.set(
+      "i",
+      "<C-k>",
+      vim.lsp.buf.signature_help,
+      vim.tbl_extend("force", opts, { desc = "LSP: signature help" })
+    )
+
+    -- Actions
+    map("<Leader>lr", vim.lsp.buf.rename, "LSP: rename symbol")
+    vim.keymap.set(
+      { "n", "v" },
+      "<leader>la",
+      vim.lsp.buf.code_action,
+      vim.tbl_extend("force", opts, { desc = "LSP: code action" })
+    )
+    map("<Leader>lf", function()
+      vim.lsp.buf.format({ async = true })
+    end, "LSP: format")
+
+    -- Diagnostics
+    map("<leader>ld", vim.diagnostic.open_float, "LSP: line diagnostics")
+    map("[d", function()
+      vim.diagnostic.jump({ count = -1, float = true })
+    end, "LSP: prev diagnostic")
+    map("]d", function()
+      vim.diagnostic.jump({ count = 1, float = true })
+    end, "LSP: next diagnostic")
+    map("<leader>lq", vim.diagnostic.setloclist, "LSP: diagnostics to loclist")
+
+    -- Workspace
+    map("<leader>lwa", vim.lsp.buf.add_workspace_folder, "LSP: add workspace folder")
+    map("<leader>lwr", vim.lsp.buf.remove_workspace_folder, "LSP: remove workspace folder")
+    map("<leader>lwl", function()
+      print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+    end, "LSP: list workspace folders")
   end,
 })

--- a/home/dot_config/nvim/plugin/mini.lua
+++ b/home/dot_config/nvim/plugin/mini.lua
@@ -1,0 +1,2 @@
+require('mini.surround').setup()
+require('mini.indentscope').setup()

--- a/home/dot_config/nvim/plugin/whichkey.lua
+++ b/home/dot_config/nvim/plugin/whichkey.lua
@@ -2,8 +2,15 @@ vim.cmd.packadd("which-key.nvim")
 
 local wk = require("which-key")
 
-wk.setup({})
+wk.setup({
+  preset = "modern",
+})
 
 wk.add({
+  { "<leader>a", group = "AI/Claude" },
+  { "<leader>f", group = "Find" },
   { "<leader>g", group = "Git" },
+  { "<leader>o", group = "OpenCode" },
+  { "<leader>l", group = "LSP" },
+  { "<leader>lw", group = "Workspace" },
 })


### PR DESCRIPTION
## Summary

The meaty Neovim expansion: new plugins and language support. Refactors `00-packs.lua` around a `gh()` helper with an avante build hook, adds agentic AI tooling (avante, copilot, CopilotChat, claudecode, opencode + deps), editing plugins (nvim-autopairs, mini.surround/indentscope, conform.nvim, vim-rails, vim-rhubarb), and several LSP servers (jsonls+schemastore, elixirls, solargraph, pyright, clangd, gopls analyses) with richer keymaps.

## Scope

- [x] Chezmoi source (`home/`)
- [x] Other: `nvim-pack-lock.json` is a vim.pack-managed plugin lock — updated as a repo snapshot and `.chezmoiignore`d so each machine owns its own copy (not a Renovate-tracked manifest).

## Verification

- [x] N/A — Neovim runtime config (Lua); not a chezmoi template or shell script.
- Plugin install + avante `make` build happen on first `nvim` launch via the `PackChanged` hook; not exercised in CI (ShellCheck/BATS/install matrix don't cover nvim Lua).

## Linked work

none