### PR TITLE
fix(zsh): make claude a function so subcommands survive --add-dir

### DIFF
--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -241,8 +241,20 @@ alias mise='GITHUB_TOKEN="$(gh auth token)" command mise'
 {{- end }}
 
 {{- if lookPath "claude" }}
-# Always give Claude Code access to source checkouts
-alias claude='claude --add-dir ~/src'
+# Give Claude Code access to source checkouts -- but as a function, not an alias.
+# A plain alias prepends `--add-dir ~/src` to EVERY invocation, and since
+# --add-dir is variadic it swallows subcommands: `claude mcp add ...` becomes
+# `claude --add-dir ~/src mcp add ...`, where --add-dir eats `mcp add` (and the
+# rest) as "directories", so the subcommand never runs. Inject --add-dir only for
+# session launches; pass management subcommands straight through.
+claude() {
+  case "$1" in
+    agents|auth|auto-mode|doctor|install|mcp|plugin|plugins|project|setup-token|ultrareview|update|upgrade)
+      command claude "$@" ;;
+    *)
+      command claude --add-dir ~/src "$@" ;;
+  esac
+}
 {{- end }}
 
 # Reload shell function - re-execs the exact same zsh binary


### PR DESCRIPTION
## What
Replace the `claude` shell alias with a function.

## Why
`alias claude='claude --add-dir ~/src'` prepended a **variadic** `--add-dir` to every invocation. `--add-dir <dirs...>` greedily consumes the tokens that follow, so:

```
claude mcp add --transport http <name> <url>
→ claude --add-dir ~/src mcp add --transport http <name> <url>
          └─ eats "~/src mcp add" as directories ─┘
```

The `mcp` subcommand never ran — its flags surfaced as `unknown option`, and `claude mcp help add` just opened a session. This broke **every** `claude` subcommand (`mcp`, `doctor`, `plugin`, `update`, …), not only MCP setup.

## Fix
A function that injects `--add-dir ~/src` only for session launches and passes management subcommands straight through:

```zsh
claude() {
  case "$1" in
    agents|auth|auto-mode|doctor|install|mcp|plugin|plugins|project|setup-token|ultrareview|update|upgrade)
      command claude "$@" ;;
    *)
      command claude --add-dir ~/src "$@" ;;
  esac
}
```

## Test
- `claude`, `claude -c`, `claude "prompt"` → still launch with `--add-dir ~/src`
- `claude mcp list` → routes correctly (previously failed with `unknown option`)