### PR TITLE
chore(git): ignore Claude Code artifacts and oil.nvim buffers :broom:

### DIFF
--- a/home/dot_config/git/ignore
+++ b/home/dot_config/git/ignore
@@ -98,3 +98,8 @@ node_modules/
 
 # Buildkite local configuration
 .bk.yaml
+
+.claude/plans
+.claude/task-summaries
+.claude/arcade
+oil:/


### PR DESCRIPTION
## Summary

Adds five entries to the global git ignore so per-session agent output and editor buffer scratch never land in the tree. `.claude/plans`, `.claude/task-summaries`, and `.claude/arcade` are regenerated each session; `oil:/` is oil.nvim's buffer path scheme and should never be tracked.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [ ] `hk check` clean
- [ ] `./bin/test` green (set `CI=1 GITHUB_ACTIONS=1` if your change touches a chezmoi template that branches on CI)
- [ ] `chezmoi diff` previewed and only intended paths changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [x] N/A — docs/config-only change

## Linked work

none

---

🤖 [Conversation log](https://gist.github.com/meaganewaller/1c6c57184d904d883edce0f984891649)