### PR TITLE
fix(mise): stop setting NODE_ENV globally :relieved:

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -4,7 +4,12 @@
 
 [env]
 # supports arbitrary env vars so mise can be used like direnv/dotenv
-NODE_ENV = "development"
+#
+# Don't set NODE_ENV here. A global value leaks into every production build on
+# the machine: `next build` inherited NODE_ENV=development and React resolved a
+# mix of its dev and prod builds, leaving ReactSharedInternals null and failing
+# the prerender with "null is not an object (evaluating 'k.H.useContext')".
+# Tools set NODE_ENV themselves; per-project mise.toml can override when needed.
 _.fnox-env = { tools = true, profile = "{{ if .work_profile }}work{{ else }}personal{{ end }}" }
 
 [settings]


### PR DESCRIPTION
## Summary

The global `NODE_ENV = "development"` in `~/.config/mise/config.toml` leaked into every project on the machine. `next build` inherited it, React resolved a mix of its dev and prod builds, and the prerender died with `null is not an object (evaluating 'k.H.useContext')` — `ReactSharedInternals` was null. Tools set `NODE_ENV` themselves, so nothing needs a global default; a per-project `mise.toml` can still override when a project genuinely wants one.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 155 tests
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Template renders verified with `chezmoi execute-template --file home/dot_config/mise/config.toml.tmpl`
- [ ] N/A — docs/config-only change

Rendered output confirms the `[env]` block keeps `_.fnox-env` intact and carries only the explanatory comment where `NODE_ENV` used to be.

## Notes for reviewers

This is the widest-reaching change of the three split out of the original branch — it alters the environment for **every** project on any machine that applies these dotfiles. It is deliberately a standalone PR so it can be reverted on its own if some project turns out to have depended on the implicit default.

The removal is a comment, not a deletion, on purpose: the failure mode it prevents is genuinely hard to diagnose from the symptom, so the reasoning lives at the site where someone would otherwise re-add the line.

Nothing sets `NODE_ENV` as a fallback afterward. That is intended — an unset `NODE_ENV` is what Node and its tooling already expect, and reintroducing a global "safe" value would recreate the same class of bug.

## Linked work

None. This is 2 of 3 split out of a shared branch; #164 was the first. The remaining one is Claude plugin enablement, independent of this and touching disjoint files.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/1a541d4ebccf18c4d08a7b7ce9d33791)
