### PR TITLE
chore(claude): tidy plugin enablement across accounts :broom:

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,7 @@
 {
-  "enabledPlugins": {},
+  "enabledPlugins": {
+    "fnox@meaganewaller-marketplace": true
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/home/.chezmoidata/claude.yaml
+++ b/home/.chezmoidata/claude.yaml
@@ -74,6 +74,7 @@ claudeData:
       - plugin-dev@claude-code-plugins
       - superpowers@superpowers-dev
       - git-workflow@meaganewaller-marketplace
+      - dotfiles@meaganewaller-marketplace
 
     mcpServers: []
 
@@ -116,8 +117,6 @@ claudeData:
 
     plugins:
       # meaganewaller-marketplace
-      - dev-collective@meaganewaller-marketplace
-      - dotfiles@meaganewaller-marketplace
       - mise@meaganewaller-marketplace
       # onlooker-community
       # - archivist@onlooker-community


### PR DESCRIPTION
## Summary

Plugin enablement housekeeping. Promotes `dotfiles@meaganewaller-marketplace` from the personal-only list to the shared list so both accounts get it, drops `dev-collective@meaganewaller-marketplace` (no longer used), and turns on `fnox@meaganewaller-marketplace` for this repo so secrets tooling is available where the dotfiles are edited.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [x] Other: repo-local `.claude/settings.json` (this repo's own overrides, not synced to `~`)

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 155 tests, including the `claude.yaml` reconciler-structure spec
- [x] `chezmoi diff` previewed and only intended paths changed — no Claude-related changes pending
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [ ] N/A — docs/config-only change

## Notes for reviewers

**Dropping `dev-collective` does not uninstall it.** `bin/sync-claude-extras` reports undeclared user-scope items as drift and only removes them when run with `--prune` (see the `prune_extra` path). So this PR stops declaring the plugin; actually removing it from a machine is a separate, deliberate `--prune` run. That is the intended conservative behavior, not an oversight.

The two files land in different places despite being one concern: `home/.chezmoidata/claude.yaml` is shared data that reaches both accounts on `chezmoi apply`, while `.claude/settings.json` is local to this repository and never syncs to `~`. Happy to split them if you would rather review those surfaces separately.

The Scope checkbox for Claude Code config names `home/dot_claude/`, but this repo has no such path — per-account config lives under `home/private_dot_claude-{personal,work}/` and its data under `home/.chezmoidata/`. Ticked it anyway as the closest honest match; the template label is stale and could use a follow-up.

## Linked work

None. This is 3 of 3 split out of a shared branch, after #164 and #165. Independent of both — disjoint files.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/e00751c67b68cb3d9f861e1f5cdd4440)
