### PR TITLE
chore(mise): pin pkl and fix the stale PR template path :broom:

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ Thanks for opening a PR. Quick orientation:
 - [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
 - [ ] CI / GitHub Actions (`.github/workflows/`)
 - [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
-- [ ] Claude Code config (`home/dot_claude/` — skills, agents, hooks)
+- [ ] Claude Code config (`home/private_dot_claude-{personal,work}/`, `home/.chezmoidata/claude.yaml` — skills, agents, hooks)
 - [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
 - [ ] Other: <!-- describe -->
 

--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@
 hk = "1.54.1"
 jq = "latest"
 "npm:markdownlint-cli" = "latest"
-pkl = "latest"
+pkl = "0.32.1"
 shfmt = "latest"
 stylua = "latest"
 


### PR DESCRIPTION
## Summary

Two small follow-ups surfaced while splitting #164–#166. Pins `pkl` to `0.32.1` so `hk` can always parse `hk.pkl`, and fixes a PR-template Scope checkbox that pointed at a directory this repo has never had.

## Scope

- [ ] Chezmoi source (`home/`)
- [x] Docs (`docs/`, `README.md`, `AGENTS.md`) — `.github/PULL_REQUEST_TEMPLATE.md`
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config
- [x] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean — confirmed through `mise exec -- hk check`, the resolution path the Stop hook uses
- [x] `./bin/test` green — 155 tests
- [ ] `chezmoi diff` previewed and only intended paths changed — N/A, nothing under `home/` changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [ ] N/A — docs/config-only change

`mise ls pkl` now reports the pin as `0.32.1` rather than resolving `latest`, and reports no missing tools.

## Notes for reviewers

**The pkl pin fixes a real, already-observed failure.** `pkl = "latest"` resolved to 0.32.1, which had never been installed on this machine. `hk` needs `pkl` to read `hk.pkl`, so it panicked with `install pkl cli to use pkl config files` whenever tools were resolved through mise. It went unnoticed because an interactive shell had a stale `pkl 0.30.2` sitting on `PATH` from an older install — so `hk check` passed by hand and failed from the hook, using two different pkl versions in the same repo. Pinning removes the drift and gives Renovate an exact version to bump.

`0.32.1` is what `latest` resolves to today, so this pins current behavior rather than changing versions. Format follows the existing `hk = "1.54.1"` convention — bare version, no `v` prefix, which is how the non-`aqua:` entries are written.

Worth noting `jq`, `npm:markdownlint-cli`, `shfmt`, `stylua`, and `aqua:suzuki-shunsuke/ghalint` are still on `latest` and carry the same latent failure mode. Left alone here to keep this reviewable; happy to pin them in a follow-up if you want the manifest fully immutable.

**On the template fix:** the Scope box read `home/dot_claude/`, but per-account config lives in `home/private_dot_claude-{personal,work}/` with data in `home/.chezmoidata/claude.yaml`. #166 modified `claude.yaml` and had no accurate box to tick — that PR ticked the stale one and flagged it, which is where this came from.

## Linked work

Follow-up to #164, #165, #166.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/1b76ae6e64a408599d8e974a6d19ae0e)
