### PR TITLE
fix(packages): trust tap-qualified casks, not just formulae :bug:

### DIFF
--- a/home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl
@@ -25,6 +25,7 @@ echo "Installing packages via brew bundle..."
      ever breaks fresh installs and CI. */ -}}
 {{ $taps := list -}}
 {{ $tapFormulae := list -}}
+{{ $tapCasks := list -}}
 {{ range .packages.darwin.brews -}}
 {{ $parts := splitList "/" . -}}
 {{ if ge (len $parts) 3 -}}
@@ -32,7 +33,20 @@ echo "Installing packages via brew bundle..."
 {{ $tapFormulae = append $tapFormulae . -}}
 {{ end -}}
 {{ end -}}
-{{ if $tapFormulae -}}
+{{/* Casks are only bundled off-CI (see below), so their taps and trust grants
+     are collected under the same condition — otherwise CI would tap and trust
+     things it never installs. This split is also why a cask-only gap sails
+     through CI and fails on a real machine. */ -}}
+{{ if not (or (env "CI") (env "GITHUB_ACTIONS")) -}}
+{{ range .packages.darwin.casks -}}
+{{ $parts := splitList "/" . -}}
+{{ if ge (len $parts) 3 -}}
+{{ $taps = append $taps (printf "%s/%s" (index $parts 0) (index $parts 1)) -}}
+{{ $tapCasks = append $tapCasks . -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ if or $tapFormulae $tapCasks -}}
 # Homebrew 6 refuses to load formulae from non-official taps until they are
 # trusted ("Refusing to load formula ... from untrusted tap ..."). Trust exactly
 # the formulae this repo declares — per formula rather than per tap, so trusting
@@ -41,6 +55,9 @@ echo "Installing packages via brew bundle..."
 if brew trust --help >/dev/null 2>&1; then
 {{ range $tapFormulae -}}
 	brew trust --formula {{ . | quote }}
+{{ end -}}
+{{ range $tapCasks -}}
+	brew trust --cask {{ . | quote }}
 {{ end -}}
 fi
 

--- a/test/run_onchange_install-packages-darwin.bats
+++ b/test/run_onchange_install-packages-darwin.bats
@@ -151,6 +151,54 @@ EOF
 	[ "$trust_line" -lt "$bundle_line" ] || fail "trust at line $trust_line must precede bundle at line $bundle_line; output was: $output"
 }
 
+@test "trusts tap-qualified casks on a dev machine" {
+	local script_file="home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl"
+
+	cat >"$TEST_TMPDIR/cask-trust-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    packages = { darwin = { brews = ["jq"], casks = ["ghostty", "nikitabobko/tap/aerospace"] } }
+EOF
+
+	# Casks only render off-CI, so this path is invisible to the CI job that
+	# skips them — a cask trust gap passes CI and fails on a real machine.
+	run env -u CI -u GITHUB_ACTIONS chezmoi execute-template --config "$TEST_TMPDIR/cask-trust-config.toml" --file "$script_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+
+	# "Refusing to load cask nikitabobko/tap/aerospace from untrusted tap ..."
+	[[ "$output" == *'brew trust --cask "nikitabobko/tap/aerospace"'* ]] || fail "output was: $output"
+
+	# The cask's tap must be declared alongside the brew taps.
+	[[ "$output" == *'tap "nikitabobko/tap"'* ]] || fail "output was: $output"
+
+	# Homebrew-core casks need neither.
+	[[ "$output" != *'brew trust --cask "ghostty"'* ]] || fail "output was: $output"
+
+	# Trust must precede the bundle that loads it.
+	local trust_line bundle_line
+	trust_line=$(printf '%s\n' "$output" | grep -n 'brew trust --cask' | head -1 | cut -d: -f1)
+	bundle_line=$(printf '%s\n' "$output" | grep -n '^brew bundle' | cut -d: -f1)
+	[ -n "$trust_line" ] || fail "no cask trust line rendered; output was: $output"
+	[ "$trust_line" -lt "$bundle_line" ] || fail "trust at $trust_line must precede bundle at $bundle_line; output was: $output"
+}
+
+@test "does not trust or tap casks on CI, where casks are skipped" {
+	local script_file="home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl"
+
+	cat >"$TEST_TMPDIR/cask-ci-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    packages = { darwin = { brews = ["jq"], casks = ["nikitabobko/tap/aerospace"] } }
+EOF
+
+	CI=true run env -u GITHUB_ACTIONS chezmoi execute-template --config "$TEST_TMPDIR/cask-ci-config.toml" --file "$script_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+
+	# The cask is not installed on CI, so neither its tap nor its trust grant
+	# belongs in the rendered script.
+	[[ "$output" != *'nikitabobko'* ]] || fail "output was: $output"
+}
+
 @test "does not render on non-darwin systems" {
 	# Test our ACTUAL script on non-darwin systems
 	local script_file="home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl"


### PR DESCRIPTION
## Summary

#169 taught the Brewfile to trust tap-qualified **formulae** and stopped there. Tap-qualified **casks** need the same grant, so `chezmoi apply` on a real machine still failed with `Refusing to load cask nikitabobko/tap/aerospace from untrusted tap nikitabobko/tap`. Collects cask taps and trust grants under the same off-CI condition the casks themselves use.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config
- [x] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 159 tests, 0 failures
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Template renders verified with `chezmoi execute-template --file home/.chezmoiscripts/run_onchange_install-packages-darwin.sh.tmpl`
- [ ] N/A — docs/config-only change

Verified where it actually matters: `chezmoi apply` on a real macOS machine, which is where the bug showed. It previously aborted on the untrusted cask; it now runs to `brew bundle complete! 55 Brewfile dependencies now installed`.

## Notes for reviewers

**CI could not have caught this, and still cannot prove the fix.** The template skips casks entirely on CI (GUI apps, licenses, GUI auth), so the cask path is the one branch CI never renders. #169 went green on every job while leaving `chezmoi apply` broken on the machine the dotfiles exist to configure — the mirror image of the original tap bug, which broke only CI because a developed machine already had the taps.

Because CI structurally cannot exercise this, the specs carry the weight, and they assert both directions:

- casks are trusted when rendering off-CI
- nothing cask-related renders on CI — no stray `tap` line, no trust grant for something that is never installed

The second spec is the one that keeps the CI branch honest. Without it, a future fix could "solve" a cask problem by tapping and trusting on CI too, and no test would object.

Trust remains per item rather than per tap, matching #169: `brew trust --cask "nikitabobko/tap/aerospace"` rather than blessing everything nikitabobko ships.

## Linked work

Follow-up to #169, which fixed the formula half of the same problem.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/225e5d88554b0f45c4c771b8e4e1c5e7)
