### PR TITLE
docs(readme): link the mise.toml that exists :broom:

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ How the pieces fit together in **this** repository (not an exhaustive list of ev
 | --- | --- |
 | **Dotfile delivery** | [Chezmoi](https://chezmoi.io/) — `sourceDir` is the working tree; `home/dot_*` → `~`; `.tmpl` for Go `text/template` |
 | **Pinned CLIs & runtimes** | [mise](https://mise.jdx.dev/) — aqua / GitHub / pipx / npm / cargo backends; user tools in `home/dot_config/mise/config.toml.tmpl` |
-| **Dev-only test tools** | Root [`.mise.toml`](.mise.toml) — BATS, ShellCheck, yq, shfmt (`./bin/setup` → `mise install`) |
+| **Dev-only test tools** | Root [`mise.toml`](mise.toml) — BATS, ShellCheck, yq, shfmt (`./bin/setup` → `mise install`) |
 | **macOS system packages** | [Homebrew](https://brew.sh/) — `brew bundle` from Chezmoi-rendered data (`run_onchange_install-packages-darwin.sh.tmpl`) |
 | **Bootstrap / trust** | `./install` — prefers OS package managers, otherwise GitHub releases; optional [cosign](https://docs.sigstore.dev/cosign/overview/) verification for downloads |
 | **CI** | [GitHub Actions](https://github.com/features/actions) — ShellCheck on scripts, matrix install + [BATS](https://github.com/bats-core/bats-core) via `./bin/test`, [jdx/mise-action](https://github.com/jdx/mise-action) |


### PR DESCRIPTION
## Summary

The tooling table in `README.md` linked `.mise.toml`, with a leading dot the file has never had, so the link 404s. Points it at `mise.toml`.

## Scope

- [ ] Chezmoi source (`home/`)
- [x] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [ ] `./bin/test` green — N/A, no code or template changed
- [ ] `chezmoi diff` previewed and only intended paths changed — N/A, nothing under `home/` changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [x] N/A — docs/config-only change

Confirmed by re-running the link sweep that found it: `README.md` no longer appears among broken relative links.

## Notes for reviewers

Found by mechanically checking every relative markdown link in the tree, not by reading. It was the only broken link outside `docs/adrs/`.

Two broken links remain, both in ADRs — `0004` points at a `run_onchange_sync-claude-settings.sh.tmpl` that no longer exists, and `0005` at a `tmux-apply-theme` that moved. Those are deliberately untouched: ADRs are historical records, and whether to repair or supersede them is a different decision, tracked in `dotfiles-l3h`.

## Linked work

Closes `dotfiles-k3x`.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/568192aeec85d7a6c514b4583a1d9f62)
