### PR TITLE
chore(mise): pin the last floating tools and install after syncing :closed_lock_with_key:

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -131,6 +131,26 @@ git pull --rebase origin main
 If `main` is not the default remote branch name, discover with
 `git symbolic-ref refs/remotes/origin/HEAD` and use that ref instead of `main`.
 
+#### 4.1 Install the versions you just pulled
+
+A merged Renovate bump moves a pin in `mise.toml`; it does not install anything.
+Until you install, the pinned version is **missing** locally and commands quietly
+run whatever older build is still on `PATH`:
+
+```bash
+mise install
+mise ls | grep -i missing   # must be empty
+```
+
+This is not hypothetical. `pkl` drifted to a version that was never installed and
+`hk` panicked with `install pkl cli to use pkl config files` — but only from the
+Stop hook, because an interactive shell had a stale `pkl` on `PATH` and passed.
+`hk` itself then repeated the pattern after its own bump. In both cases lint was
+"green" against a binary the repo no longer asked for.
+
+Report any tool that fails to install rather than continuing silently; a missing
+pin makes every later verification in this run untrustworthy.
+
 ### 5. Rebase other local branches (if you started elsewhere)
 
 If the saved **original branch** was not `main`:
@@ -190,6 +210,7 @@ If `mise` hooks install tools and a download fails, report and continue cleanup/
 | --- | --- |
 | PRs merged | e.g. `#121`, `#122` + short titles |
 | Skipped / held | PRs with failing CI or needing Package Manager |
+| Tools | `mise install` result; any pin still reported missing |
 | Git | `main` sync, rebases, stash pop outcome |
 | Chezmoi | Applied? Drift remaining per `chezmoi status`? |
 | Push | Done / skipped (`--push` / not) |

--- a/mise.toml
+++ b/mise.toml
@@ -5,13 +5,13 @@
 "aqua:gitleaks/gitleaks" = "v8.30.1"
 "aqua:koalaman/shellcheck" = "v0.11.0"
 "aqua:mikefarah/yq" = "v4.53.3"
-"aqua:suzuki-shunsuke/ghalint" = "latest"
+"aqua:suzuki-shunsuke/ghalint" = "1.5.6"
 hk = "1.55.0"
-jq = "latest"
-"npm:markdownlint-cli" = "latest"
+jq = "1.8.2"
+"npm:markdownlint-cli" = "0.49.1"
 pkl = "0.32.1"
-shfmt = "latest"
-stylua = "latest"
+shfmt = "3.13.1"
+stylua = "2.5.2"
 
 [tasks.lint]
 description = "Lint and auto-fix"


### PR DESCRIPTION
## Summary

Five `mise.toml` entries still resolved `latest` at runtime, so a pin could drift to a version nobody had installed. All are now exact. Pinning alone does not close the trap, so the update workflow also installs what it just pulled and verifies nothing is missing.

## Scope

- [ ] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config
- [x] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 159 tests, 0 failures
- [ ] `chezmoi diff` previewed and only intended paths changed — N/A, nothing under `home/` changed
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [ ] N/A — docs/config-only change

After pinning, `mise install` succeeds and `mise ls` reports nothing missing. Spot-checked that the pinned versions are what actually run: `hk 1.55.0`, `shfmt v3.13.1`, `jq-1.8.2`.

## Notes for reviewers

**Versions are what `latest` already resolved to**, so this freezes current behavior rather than bundling five upgrades. Renovate takes the bumps from here, which is the point — an exact pin is something it can propose against, a floating one is not.

**Why the workflow change is the important half.** A merged Renovate bump moves the pin; it installs nothing. Until someone installs, the pinned version is missing locally and commands fall back to whatever older build is on `PATH`. That produced two separate incidents in one day:

- `pkl` drifted to 0.32.1, never installed, and `hk` panicked with `install pkl cli to use pkl config files` — but only from the Stop hook. An interactive shell had a stale 0.30.2 on `PATH` and passed, so `hk check` was simultaneously green by hand and fatal from the hook.
- `hk` itself repeated it hours later after its own bump to 1.55.0, with lint passing against 1.54.1.

In both cases the verification everyone trusts was running against a binary the repo no longer asked for. `mise install` after sync, plus a missing check, is what stops that.

**On routing:** `AGENTS.md` sends manifest edits through the Package Manager subagent. This freezes already-resolved versions rather than choosing new ones, and the ghalint entry keeps its bare form (`1.5.6`) because that is what its aqua backend resolved — unlike the other `aqua:` entries, which carry a `v` prefix. Happy to re-route if you would rather that rule hold without exception.

## Linked work

Closes `dotfiles-z8e`.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/568192aeec85d7a6c514b4583a1d9f62)
