### PR TITLE
feat(claude): adopt Conor Bronsdon's avoid-ai-writing plugin :writing_hand:

### DIFF
--- a/home/.chezmoidata/claude.yaml
+++ b/home/.chezmoidata/claude.yaml
@@ -68,6 +68,8 @@ claudeData:
         repo: obra/superpowers
       - name: meaganewaller-marketplace
         repo: meaganewaller/marketplace
+      - name: conorbronsdon-skills
+        repo: conorbronsdon/avoid-ai-writing
 
     plugins:
       - claude-api@anthropic-agent-skills
@@ -75,6 +77,7 @@ claudeData:
       - superpowers@superpowers-dev
       - git-workflow@meaganewaller-marketplace
       - dotfiles@meaganewaller-marketplace
+      - avoid-ai-writing@conorbronsdon-skills
 
     mcpServers: []
 
@@ -151,7 +154,7 @@ claudeData:
       - name: testdouble-skills-internal
         repo: testdouble/skills-internal
 
-    plugins: 
+    plugins:
       - han@testdouble-skills-internal
 
     mcpServers: []


### PR DESCRIPTION
## Summary

Adopts [`conorbronsdon/avoid-ai-writing`](https://github.com/conorbronsdon/avoid-ai-writing) as a marketplace plugin, replacing the hand-maintained `avoid-ai-writing` skill that used to sit in `~/.claude-{personal,work}/skills/`.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/.chezmoidata/claude.yaml`)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 159 tests, 0 failures, including the `claude.yaml` reconciler-structure spec
- [ ] `chezmoi diff` previewed and only intended paths changed — data file; nothing renders until `sync-claude-extras` runs
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [ ] N/A — docs/config-only change

**Identifiers checked against the upstream manifest** rather than assumed. `.claude-plugin/marketplace.json` in that repo declares `"name": "conorbronsdon-skills"` and a plugin `"name": "avoid-ai-writing"`, matching the marketplace and plugin strings here — so `bin/sync-claude-extras` will find what it looks for instead of failing at reconcile time. The repo is live and not archived.

Scope confirmed with `yq`, not by reading indentation: the plugin lands under `shared`.

## Notes for reviewers

**Why `shared`.** One row reaches both accounts and the version is managed upstream — the argument for plugins over per-account `SKILL.md` files that #177 documented. The skill this replaces had to be copied into each account by hand, which is how the two copies drifted apart.

**What it replaces was partly broken anyway.** The old hand-maintained copy invoked `node detector/validate.js` and `node scripts/check-style.js`, neither of which ever shipped — tracked as `dotfiles-gs4` and closed as obsolete once the copies were deleted. So this is not a like-for-like swap; it is replacing something whose tooling half never worked.

**One unrelated fix folded in:** a stray trailing space on the work scope's `plugins:` key. It is pre-existing and has nothing to do with this change, but `hk` lints whole changed files, so the latent violation blocks any commit touching `claude.yaml`. Same shape as the `.beads/config.yaml` newline in #174 — a committed whitespace violation stays invisible until an unrelated edit trips over it. Splitting it out would have required interactive hunk staging on a single file for one character.

## Linked work

Follows #177, which established that skills come from plugins rather than this tree. Related to `dotfiles-gs4`, closed as obsolete.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/e96f7d3ec829d58bc926ec4a683a74cc)
