### PR TITLE
feat(claude): declare typescript-lsp so it stops reading as drift :nail_care:

### DIFF
--- a/home/.chezmoidata/claude.yaml
+++ b/home/.chezmoidata/claude.yaml
@@ -78,6 +78,9 @@ claudeData:
       - git-workflow@meaganewaller-marketplace
       - dotfiles@meaganewaller-marketplace
       - avoid-ai-writing@conorbronsdon-skills
+      # claude-plugins-official is a built-in marketplace, so it needs no
+      # marketplaces entry — only the plugin is ours to declare.
+      - typescript-lsp@claude-plugins-official
 
     mcpServers: []
 


### PR DESCRIPTION
## Summary

`typescript-lsp@claude-plugins-official` is installed on both accounts but was declared nowhere, so `bin/sync-claude-extras --check` reported it as an undeclared extra on every run. Declares it under `shared`, matching where it is actually installed.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [x] Claude Code config (`home/.chezmoidata/claude.yaml`)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 159 tests, 0 failures, including the `claude.yaml` reconciler-structure spec
- [ ] `chezmoi diff` previewed and only intended paths changed — data file; nothing renders until `sync-claude-extras` runs
- [ ] Template renders verified with `chezmoi execute-template --file <path>` (if you touched a `.tmpl`)
- [ ] N/A — docs/config-only change

Confirmed against each account's `plugins/installed_plugins.json`: `typescript-lsp@claude-plugins-official` is present at user scope in both personal and work, which is what makes `shared` the right home rather than one account.

## Notes for reviewers

**No `marketplaces` entry accompanies this, deliberately.** `claude-plugins-official` is the built-in marketplace named in `BUILTIN_MARKETPLACES` in [`bin/sync-claude-extras`](../../bin/sync-claude-extras), which the reconciler never flags or prunes because it is not ours to manage. Declaring it would claim something Claude Code already owns, and the reconciler would ignore the row anyway.

**Related cleanup done outside this PR.** The same drift report also flagged `testdouble-skills-internal` as undeclared. That one turned out to be already declared — under `work`, alongside `han@testdouble-skills-internal` — and installed on *both* accounts, so only the personal-side installation was stray. It has since been pruned: personal's `known_marketplaces.json` no longer lists it, work's still does. No change to this repo was needed for it.

Worth noting for future drift triage: the reconciler evaluates each account against its own declared set, so "installed but not declared" can mean *declared in a scope this account does not see* rather than genuinely undeclared. Check the scope before adding a row.

## Linked work

Follows #178, which adopted the avoid-ai-writing plugin under the same `shared` scope.

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/daf7fa6c5e2c9a45ab40772efc0c6968)
