### PR TITLE
feat(loop): manage the trigger key and move it off Shift :video_game:

### DIFF
--- a/home/.chezmoidata/loop.yaml
+++ b/home/.chezmoidata/loop.yaml
@@ -1,0 +1,28 @@
+# Loop — manual window snapping for floating windows (see ADR 0007).
+#
+# Only the trigger surface is pinned here. Loop owns the rest of its
+# preferences (accent colors, padding, radial menu, per-direction keybinds,
+# icon); declaring those would mean fighting the app on every in-app tweak,
+# and the color values are opaque binary plists anyway.
+#
+# `trigger` is a list of macOS virtual keycodes. Loop reads them as an array,
+# so a multi-key trigger is just more entries. Reference:
+#
+#   54  right Command      56  left Shift      59  left Control
+#   55  left Command       60  right Shift     62  right Control
+#   57  Caps Lock          58  left Option     61  right Option
+#
+# Right Option is chosen because every other candidate is spoken for:
+# left Shift (the old trigger) is Minecraft's sneak, so gameplay kept firing
+# the radial menu; Caps Lock and right Command are consumed by Karabiner
+# (→ left Control and → F18 respectively, see home/dot_config/karabiner/);
+# left Control is Minecraft's sprint. AeroSpace binds alt+<key> chords rather
+# than bare Option, so a held right Option does not collide with it.
+loop:
+  trigger: [61]
+  # Left and right of the same modifier are distinct triggers; without this,
+  # left Option would fire Loop too and re-introduce a gameplay collision.
+  side_dependent_trigger_key: true
+  # Double-tap rather than hold. Kept as-is from the previous setup so only
+  # the key changes, not the gesture.
+  double_click_to_trigger: true

--- a/home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl
@@ -1,0 +1,63 @@
+{{ if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+[ -n "${DEBUG:-}" ] && set -o xtrace
+set -o errexit
+set -o nounset
+
+# Skip on CI: Loop is a GUI app that is not installed on runners, and the
+# restart below needs a login session.
+{{ template "ci-skip-guard" "Running in CI, skipping Loop configuration" }}
+# Nothing to configure if Loop was never installed (the cask is macOS-only and
+# skipped on CI, so this is the normal state in containers too).
+if [ ! -d "/Applications/Loop.app" ]; then
+    echo "Loop not installed, skipping"
+    exit 0
+fi
+
+loop_changed=false
+
+# Trigger key(s). Loop stores these as an array of macOS virtual keycodes; the
+# read is normalized by stripping the parens, commas and whitespace `defaults`
+# prints so the comparison is a plain string.
+desired_trigger="{{ range .loop.trigger }}{{ . }}{{ end }}"
+current_trigger="$(defaults read com.MrKai77.Loop trigger 2>/dev/null | tr -d '[:space:](),' || true)"
+
+if [ "${current_trigger}" = "${desired_trigger}" ]; then
+    echo "Loop trigger already set to ${desired_trigger}, skipping"
+else
+    echo "Setting Loop trigger to ${desired_trigger}..."
+    defaults write com.MrKai77.Loop trigger -array{{ range .loop.trigger }} -int {{ . }}{{ end }}
+    loop_changed=true
+fi
+
+# Side-dependent trigger: without it, the mirrored modifier fires Loop too.
+desired_side={{ if .loop.side_dependent_trigger_key }}1{{ else }}0{{ end }}
+if [ "$(defaults read com.MrKai77.Loop sideDependentTriggerKey 2>/dev/null || echo unset)" = "${desired_side}" ]; then
+    echo "Loop sideDependentTriggerKey already ${desired_side}, skipping"
+else
+    echo "Setting Loop sideDependentTriggerKey to ${desired_side}..."
+    defaults write com.MrKai77.Loop sideDependentTriggerKey -bool {{ .loop.side_dependent_trigger_key }}
+    loop_changed=true
+fi
+
+# Double-tap vs hold to open the radial menu.
+desired_double={{ if .loop.double_click_to_trigger }}1{{ else }}0{{ end }}
+if [ "$(defaults read com.MrKai77.Loop doubleClickToTrigger 2>/dev/null || echo unset)" = "${desired_double}" ]; then
+    echo "Loop doubleClickToTrigger already ${desired_double}, skipping"
+else
+    echo "Setting Loop doubleClickToTrigger to ${desired_double}..."
+    defaults write com.MrKai77.Loop doubleClickToTrigger -bool {{ .loop.double_click_to_trigger }}
+    loop_changed=true
+fi
+
+# Loop reads its preferences at launch, so a write alone leaves the old trigger
+# live until the next login. Only restart when something actually changed, and
+# only if it is already running — starting Loop on a machine where it is
+# deliberately quit would be a surprise.
+if [ "${loop_changed}" = true ] && pgrep -xq Loop; then
+    echo "Restarting Loop so the new trigger takes effect..."
+    killall Loop || true
+    open -a Loop
+fi
+{{ end -}}

--- a/test/run_onchange_configure-loop.bats
+++ b/test/run_onchange_configure-loop.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "loop.yaml is valid YAML with the structure the script expects" {
+	local data_file="home/.chezmoidata/loop.yaml"
+
+	[ -f "$data_file" ] || fail "assertion did not hold"
+	assert_valid_yaml "$data_file"
+
+	# The script reads .loop.trigger, .loop.side_dependent_trigger_key and
+	# .loop.double_click_to_trigger; a rename would render an empty trigger.
+	run yq '.loop.trigger' "$data_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+	run yq '.loop.side_dependent_trigger_key' "$data_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+	run yq '.loop.double_click_to_trigger' "$data_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+}
+
+@test "the declared trigger is not a key another tool already owns" {
+	local data_file="home/.chezmoidata/loop.yaml"
+
+	# 56 was the old trigger (left Shift) and is Minecraft's sneak; 57 and 54
+	# are consumed by Karabiner (caps_lock -> left_control, right_command ->
+	# f18). Re-declaring any of them silently reintroduces a collision.
+	run yq -r '.loop.trigger | .[]' "$data_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+
+	local code
+	while IFS= read -r code; do
+		[ -n "$code" ] || continue
+		case "$code" in
+		56) fail "trigger $code is left Shift — Minecraft sneak, the collision this replaced" ;;
+		57) fail "trigger $code is Caps Lock — Karabiner remaps it to left_control" ;;
+		54) fail "trigger $code is right Command — Karabiner remaps it to f18" ;;
+		esac
+	done < <(printf '%s\n' "$output")
+}
+
+@test "renders on darwin with the declared trigger" {
+	local script_file="home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl"
+
+	cat >"$TEST_TMPDIR/loop-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    loop = { trigger = [61], side_dependent_trigger_key = true, double_click_to_trigger = true }
+EOF
+
+	run env -u CI -u GITHUB_ACTIONS chezmoi --source home execute-template --config "$TEST_TMPDIR/loop-config.toml" --file "$script_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+
+	assert_script_structure "$output"
+
+	# Keycodes must reach `defaults` as integers; -array alone would write strings.
+	[[ "$output" == *'defaults write com.MrKai77.Loop trigger -array -int 61'* ]] || fail "output was: $output"
+
+	# Guard against clobbering a machine where Loop was never installed.
+	[[ "$output" == *"/Applications/Loop.app"* ]] || fail "output was: $output"
+
+	# A write without a restart leaves the old trigger live until next login.
+	[[ "$output" == *"killall Loop"* ]] || fail "output was: $output"
+}
+
+@test "renders a multi-key trigger as repeated -int arguments" {
+	local script_file="home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl"
+
+	cat >"$TEST_TMPDIR/multi-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    loop = { trigger = [61, 62], side_dependent_trigger_key = true, double_click_to_trigger = false }
+EOF
+
+	run env -u CI -u GITHUB_ACTIONS chezmoi --source home execute-template --config "$TEST_TMPDIR/multi-config.toml" --file "$script_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+
+	[[ "$output" == *'trigger -array -int 61 -int 62'* ]] || fail "output was: $output"
+
+	# The comparison string must concatenate in the same order the array is
+	# written, or the idempotency check rewrites on every apply.
+	[[ "$output" == *'desired_trigger="6162"'* ]] || fail "output was: $output"
+
+	# A false value must render 0, not the empty string.
+	[[ "$output" == *"desired_double=0"* ]] || fail "output was: $output"
+}
+
+@test "does not render on non-darwin systems" {
+	local script_file="home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl"
+
+	cat >"$TEST_TMPDIR/linux-config.toml" <<EOF
+[data]
+    chezmoi = { os = "linux", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    loop = { trigger = [61], side_dependent_trigger_key = true, double_click_to_trigger = true }
+EOF
+
+	run chezmoi --source home execute-template --config "$TEST_TMPDIR/linux-config.toml" --file "$script_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+	[ "$output" = "" ] || fail "output was: $output"
+}
+
+@test "produces valid shell syntax" {
+	local script_file="home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl"
+
+	cat >"$TEST_TMPDIR/syntax-config.toml" <<EOF
+[data]
+    chezmoi = { os = "darwin", homeDir = "$TEST_HOME_DIR", sourceDir = "$TEST_SOURCE_DIR" }
+    loop = { trigger = [61], side_dependent_trigger_key = true, double_click_to_trigger = true }
+EOF
+
+	run env -u CI -u GITHUB_ACTIONS chezmoi --source home execute-template --config "$TEST_TMPDIR/syntax-config.toml" --file "$script_file"
+	[ "$status" -eq 0 ] || fail "status=$status output=$output"
+
+	assert_valid_shell "$output"
+}


### PR DESCRIPTION
## Summary

Loop's trigger was left Shift on a double-tap — also Minecraft's sneak, so playing the game kept opening the radial menu. Moves it to right Option and brings the trigger surface into the tree, which is the follow-up ADR 0007 deferred when it said Loop's own settings stay with Loop "for now".

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config
- [x] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [x] `hk check` clean
- [x] `./bin/test` green — 165 tests, 0 failures (159 + 6 new)
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Template renders verified with `chezmoi --source home execute-template --file home/.chezmoiscripts/run_onchange_configure-loop.sh.tmpl`

Applied on a real machine, not just rendered. Before: `trigger = (56)`. After `chezmoi apply`:

```
Setting Loop trigger to 61...
Loop sideDependentTriggerKey already 1, skipping
Loop doubleClickToTrigger already 1, skipping
Restarting Loop so the new trigger takes effect...
```

`defaults read com.MrKai77.Loop trigger` now returns `61`, and Loop relaunched. Running the rendered script a second time reports all three as already-set, exits 0, and does **not** restart Loop — the idempotency guards hold.

## Notes for reviewers

**Why right Option specifically.** Every other candidate is taken: Caps Lock and right Command are consumed by Karabiner (remapped to `left_control` and `f18`), left Control is Minecraft's sprint, and left Shift is the sneak collision being fixed. AeroSpace binds `alt+<key>` chords rather than bare Option, so a held right Option does not contend with it. `sideDependentTriggerKey` stays on — without it left Option fires Loop too and puts the collision straight back, which is why there is a spec asserting it.

**Scope is deliberately narrow.** Only `trigger`, `sideDependentTriggerKey` and `doubleClickToTrigger` are declared. Loop keeps colors, padding, radial-menu settings, per-direction keybinds and icon. Pinning those would mean fighting the app on every in-app tweak, and the color values are opaque binary plists. Same division as `sync-claude-settings`: own the declared keys, leave the rest.

**The restart is conditional in both directions** — only when a value actually changed, and only if Loop is already running. Loop reads preferences at launch, so a write without a restart leaves the old trigger live until next login; but launching Loop on a machine where it was deliberately quit would be a surprise.

**One spec is a guard rather than a test of behavior:** it fails if the declared trigger is ever set to 56, 57, or 54, each with the reason. Those are the keys another tool already owns, and re-declaring one would silently recreate a collision that is tedious to diagnose from the symptom.

## Linked work

Implements the follow-up left open by ADR [0007](../../docs/adrs/0007-window-management-strategy.md).

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/de7bc4029e08adc3040033663d7358de)
