### PR TITLE
fix(mise): point claude-extract at the patched fork :compass:

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -199,7 +199,13 @@ pnpm    = "latest"
 "aqua:rtk-ai/rtk"                    = "latest" # High-performance CLI proxy that reduces LLM token consumption by 60-90%
 "github:dyoshikawa/rulesync"         = "latest" # A Utility CLI for AI Coding Agents
 "github:googleworkspace/cli"         = "latest" # Google Workspace CLI
-"pipx:claude-conversation-extractor" = "latest" # `claude-extract` CLI — used by the `/pr` skill to gist session logs
+# Fork, pinned by SHA. Upstream hardcodes ~/.claude/projects and ignores
+# CLAUDE_CONFIG_DIR, which this machine sets — so it reports zero sessions on a
+# machine holding ~1500. Pinned rather than tracking @main because mise caches
+# the build: a moving branch would go stale silently, which is exactly how the
+# previous shim-level fix got reverted by an upstream release.
+# Bump the SHA deliberately to pick up fork changes.
+"pipx:git+https://github.com/meaganewaller/claude-conversation-extractor.git@440cc59" = "latest" # `claude-extract` CLI — used by the `/pr` skill to gist session logs
 
 ### MCP servers
 "pipx:mcp-server-time"  = "latest" # MCP server for time and timezone conversion capabilities


### PR DESCRIPTION
## Summary

`claude-extract` reported zero sessions on a machine holding ~1500, because
upstream hardcodes `~/.claude/projects` and ignores `CLAUDE_CONFIG_DIR` — which
this machine sets. That broke the `/pr` skill's conversation-log step on every
PR from here, in every repo. This points the pin at a patched fork.

## Scope

- [x] Chezmoi source (`home/`)
- [ ] Docs (`docs/`, `README.md`, `AGENTS.md`)
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Pinned manifests / Renovate (mise, chezmoi externals, brew bundle, GHA digests)
- [ ] Claude Code config (`home/private_dot_claude-{personal,work}/`, `home/.chezmoidata/claude.yaml` — skills, agents, hooks)
- [ ] Repo tooling (`bin/`, `test/`, `hk.pkl`, `mise.toml`)
- [ ] Other:

## Verification

- [ ] `hk check` clean
- [x] `./bin/test` green (165/165, zero failures)
- [x] `chezmoi diff` previewed and only intended paths changed
- [x] Template renders verified with `chezmoi execute-template --file <path>`
- [ ] N/A — docs/config-only change

**`hk check` was not run** — it needs the `pkl` CLI, which is not installed on
this machine, and installing a toolchain dependency was out of scope for this
change. Worth knowing that gate is currently unrunnable here.

Beyond the checkboxes, verified from the **installed package** rather than the
working tree, since that distinction turned out to matter (see below):
`claude-extract` lists 1491 sessions, `claude-extract-session` extracts one, and
the gist footer on this very PR was produced by the fixed tool.

## Notes for reviewers

**Why a fork rather than fixing the shim again.** The shim-level fix was already
made once and got reverted when upstream published 1.1.2 and `"latest"` pulled
it in. Any wrapper has the same fate; the spec had to stop tracking upstream.

**Why pinned by SHA rather than `@main`.** mise caches the build, so a moving
branch goes stale silently — the same failure mode in a new coat. Bumping the
SHA is now the deliberate act of taking fork changes. Per `docs/renovate.md`,
an entry left at `latest` is out of Renovate's scope by design, and the existing
`pipx:` regex manager requires a digit-leading value, so it will not match or
mangle this line. The `git-refs` `customManagers` guidance in that doc applies
to chezmoi externals, not mise entries — so no manager rule is added here. Say
the word if you would rather have one so Renovate proposes fork bumps.

**The fork needed a second commit, and the reason is worth flagging.** The first
fix was complete and its tests passed, but the installed tool was entirely
broken: the new module was not in either packaging manifest, so pip shipped
everything except it and the console script died on import. The test suite could
not have caught it — `conftest.py` puts `src/` on `sys.path`, so imports resolve
in-tree regardless of what is packaged. Only a real install surfaced it. The
fork now carries a guard comparing both manifests against the modules on disk.

Fork commits, on `meaganewaller/claude-conversation-extractor@main`:

| SHA | |
|---|---|
| `8f84e74` | `fix(gitignore): stop hiding new test files from git` |
| `e3114a6` | `fix: honor CLAUDE_CONFIG_DIR when locating conversations` |
| `440cc59` | `fix(packaging): ship the module the config-dir fix depends on` |

Nothing was sent upstream to ZeroSumQuant; this is a private fork by intent.

**Unrelated thing noticed, not touched:** `home/dot_config/mise/mise.lock` is
tracked in git but listed in `.chezmoiignore`, so it is never applied — inert
and already stale. It will keep drifting.

## Linked work

none

---
🤖 [Conversation log](https://gist.github.com/meaganewaller/c43571837baa839083cbb432241eaa5b)